### PR TITLE
Add necessary import to GraphQL Upload example

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -260,6 +260,7 @@ mutation($files: [Upload!]!) {
 
 ```dart
 import "package:http/http.dart" show Multipartfile;
+import 'package:http_parser/http_parser.dart' show MediaType;
 
 // ...
 

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -260,7 +260,7 @@ mutation($files: [Upload!]!) {
 
 ```dart
 import "package:http/http.dart" show Multipartfile;
-import 'package:http_parser/http_parser.dart' show MediaType;
+import "package:http_parser/http_parser.dart" show MediaType;
 
 // ...
 


### PR DESCRIPTION
MediaType is not visible from `http` package, you need to import `http_parser.dart` in order to be able to use it. Android Studio did not propose importing this for me, which caused mild confusion for a good few minutes.

Describe the purpose of the pull request.

#### Docs

- Updated GraphQL Upload usage example, adding necessary import statement.
