### PR TITLE
fix: rebroadcasting for subscriptions

### DIFF
--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -101,6 +101,8 @@ class QueryManager {
             response,
             queryResult,
           );
+
+          maybeRebroadcastQueries();
         } catch (failure, trace) {
           // we set the source to indicate where the source of failure
           queryResult ??= QueryResult(source: QueryResultSource.network);


### PR DESCRIPTION
For one of our projects we are using GraphQL queries in combination with subscriptions to dynamically update our UI. Using the build-in cache mechanism we should be able to update existing entities when arriving through subscriptions (this actually would be similar as Apollo). It looks like the code misses a `maybeRebroadcastQueries` after data is written to the cache.

Simplified example usage:
```dart
    final dataQuery = GetDataQuery();
    final dataSubscription = DataChangedSubscription();

    final query = client.watchQuery(WatchQueryOptions(
        document: dataQuery.document,
        fetchPolicy: FetchPolicy.cacheAndNetwork,
        fetchResults: true
    ));
    final dataStream = query.stream;

    client.subscribe(SubscriptionOptions(
            document: dataSubscription.document,
    )).listen((event) { });
```

### Breaking changes

- None as far as I know.

#### Fixes / Enhancements

- Add `maybeRebroadcastQueries` on subscription data retrieval.

#### Docs

- Nothing added / updated / removed.
