### PR TITLE
Fix websocket disconnect after connection loss

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -4,6 +4,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:graphql/src/links/gql_links.dart';
+import 'package:graphql/src/utilities/platform.dart';
 import 'package:meta/meta.dart';
 
 import 'package:graphql/src/core/query_options.dart' show WithType;
@@ -22,7 +23,7 @@ import './websocket_messages.dart';
 typedef GetInitPayload = FutureOr<dynamic> Function();
 
 /// A definition for functions that returns a connected [WebSocketChannel]
-typedef WebSocketConnect = WebSocketChannel Function(
+typedef WebSocketConnect = FutureOr<WebSocketChannel> Function(
   Uri uri,
   Iterable<String>? protocols,
 );
@@ -102,11 +103,15 @@ class SocketClientConfig {
   /// ```
   final WebSocketConnect connect;
 
-  static WebSocketChannel defaultConnect(
+  static Future<WebSocketChannel> defaultConnect(
     Uri uri,
     Iterable<String>? protocols,
-  ) =>
-      WebSocketChannel.connect(uri, protocols: protocols).forGraphQL();
+  ) async {
+    return defaultConnectPlatform(
+      uri,
+      protocols,
+    );
+  }
 
   /// Payload to be sent with the connection_init request.
   ///
@@ -222,7 +227,7 @@ class SocketClient {
       // Even though config.connect is sync, we call async in order to make the
       // SocketConnectionState.connected attribution not overload SocketConnectionState.connecting
       socketChannel =
-          await config.connect(Uri.parse(url), protocols).forGraphQL();
+          (await config.connect(Uri.parse(url), protocols)).forGraphQL();
       _connectionStateController.add(SocketConnectionState.connected);
       print('Connected to websocket.');
       _write(initOperation);

--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -226,8 +226,8 @@ class SocketClient {
     try {
       // Even though config.connect is sync, we call async in order to make the
       // SocketConnectionState.connected attribution not overload SocketConnectionState.connecting
-      socketChannel =
-          (await config.connect(Uri.parse(url), protocols)).forGraphQL();
+      var connection = await config.connect(Uri.parse(url), protocols);
+      socketChannel = connection.forGraphQL();
       _connectionStateController.add(SocketConnectionState.connected);
       print('Connected to websocket.');
       _write(initOperation);

--- a/packages/graphql/lib/src/utilities/platform.dart
+++ b/packages/graphql/lib/src/utilities/platform.dart
@@ -1,3 +1,1 @@
-export './platform_stub.dart'
-    if (dart.library.html) './platform_html.dart'
-    if (dart.library.io) './platform_io.dart';
+export './platform_html.dart' if (dart.library.io) './platform_io.dart';

--- a/packages/graphql/lib/src/utilities/platform_html.dart
+++ b/packages/graphql/lib/src/utilities/platform_html.dart
@@ -1,2 +1,11 @@
-final isHtml = true;
-final isIo = false;
+import 'package:graphql/src/links/websocket_link/websocket_client.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+Future<WebSocketChannel> defaultConnectPlatform(
+  Uri uri,
+  Iterable<String>? protocols,
+) async {
+  final webSocketChannel =
+      await WebSocketChannel.connect(uri, protocols: protocols);
+  return webSocketChannel.forGraphQL();
+}

--- a/packages/graphql/lib/src/utilities/platform_io.dart
+++ b/packages/graphql/lib/src/utilities/platform_io.dart
@@ -1,2 +1,14 @@
-final isHtml = false;
-final isIo = true;
+import 'dart:io';
+
+import 'package:graphql/src/links/websocket_link/websocket_client.dart';
+import 'package:web_socket_channel/io.dart';
+import 'package:web_socket_channel/web_socket_channel.dart';
+
+Future<WebSocketChannel> defaultConnectPlatform(
+  Uri uri,
+  Iterable<String>? protocols,
+) async {
+  final webSocket =
+      await WebSocket.connect(uri.toString(), protocols: protocols);
+  return IOWebSocketChannel(webSocket).forGraphQL();
+}

--- a/packages/graphql/lib/src/utilities/platform_stub.dart
+++ b/packages/graphql/lib/src/utilities/platform_stub.dart
@@ -1,2 +1,0 @@
-final isHtml = false;
-final isIo = false;


### PR DESCRIPTION
Changes requested for #888
Fix #856

`platform_stub.dart` was unused as well as `isHtml` and `isIo` booleans.