### PR TITLE
Add necessary import to GraphQL Upload example

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -261,6 +261,7 @@ mutation($files: [Upload!]!) {
 
 ```dart
 import "package:http/http.dart" show Multipartfile;
+import "package:http_parser/http_parser.dart" show MediaType;
 
 // ...
 


### PR DESCRIPTION
MediaType is not visible from http package, you need to import http_parser.dart in order to be able to use it.
