### PR TITLE
feat: Update normalize

### DIFF
--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -13,7 +13,7 @@ dependencies:
   gql_error_link: ^0.2.0
   gql_dedupe_link: ^2.0.0
   hive: ^2.0.0
-  normalize: ^0.5.3
+  normalize: ^0.6.0
   http: ^0.13.0
   collection: ^1.15.0
   web_socket_channel: ^2.0.0


### PR DESCRIPTION
Update normalize to `0.6.0` and update documentation. Related issue: #994

### Breaking changes

- We're updating to a new "major" version of normalize. This introduces improved fragment handling.

#### Fixes / Enhancements

- Updated normalize to version `0.6.0`.

#### Docs

- Added docs describing how the new fragments are handled.
