### PR TITLE
Fix close websocket on web and a few related cleanups

### DIFF
--- a/.github/workflows/graphql_codcoverage.yml
+++ b/.github/workflows/graphql_codcoverage.yml
@@ -17,8 +17,8 @@ jobs:
           dart pub get
           pub run test --coverage="coverage"
           pub run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          file: packages/graphql/coverage.lcov
+      - name: Upload coverage file
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov --file packages/graphql/coverage.lcov

--- a/.github/workflows/graphql_flutter_codcoverage.yml
+++ b/.github/workflows/graphql_flutter_codcoverage.yml
@@ -14,8 +14,8 @@ jobs:
           cd packages/graphql_flutter
           flutter pub get
           flutter test --coverage
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v1.0.2
-        with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          file: packages/graphql_flutter/coverage/lcov.info
+      - name: Upload coverage file
+        run: |
+          curl -Os https://uploader.codecov.io/latest/linux/codecov
+          chmod +x codecov
+          ./codecov --file packages/graphql_flutter/coverage/lcov.info

--- a/README.md
+++ b/README.md
@@ -121,8 +121,8 @@ This project follows the [all-contributors](https://github.com/kentcdodds/all-co
 
 [build-status-badge]: https://img.shields.io/github/workflow/status/zino-hofmann/graphql-flutter/graphql-flutter%20Tests%20case?style=flat-square
 [build-status-link]: https://github.com/zino-hofmann/graphql-flutter/actions
-[coverage-badge]: https://img.shields.io/codecov/c/github/zino-app/graphql-flutter.svg?style=flat-square
-[coverage-link]: https://codecov.io/gh/zino-app/graphql-flutter
+[coverage-badge]: https://img.shields.io/codecov/c/github/zino-hofmann/graphql-flutter/beta?style=flat-square
+[coverage-link]: https://app.codecov.io/gh/zino-hofmann/graphql-flutter
 [version-badge]: https://img.shields.io/pub/v/graphql_flutter.svg?style=flat-square
 [package-link]: https://pub.dartlang.org/packages/graphql_flutter
 [package-link-client]: https://pub.dartlang.org/packages/graphql

--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -247,7 +247,9 @@ class SocketClient {
       _messageSubscription = _messages.listen(
         onMessage,
         onDone: onConnectionLost,
-        cancelOnError: true,
+        // onDone will not be triggered if the subscription is
+        // auto-cancelled on error; make sure to pass false
+        cancelOnError: false,
         onError: onStreamError,
       );
 
@@ -457,7 +459,7 @@ class SocketClient {
 }
 
 void _defaultOnStreamError(Object error, StackTrace st) {
-  print('[SocketClient] message stream ecnountered error: $error\n'
+  print('[SocketClient] message stream encountered error: $error\n'
       'stacktrace:\n${st.toString()}');
 }
 

--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -173,6 +173,7 @@ class SocketClient {
       HashMap();
 
   bool _connectionWasLost = false;
+  bool _wasDisposed = false;
 
   Timer? _reconnectTimer;
 
@@ -201,10 +202,22 @@ class SocketClient {
       config.inactivityTimeout!,
       onTimeout: (EventSink<ConnectionKeepAlive> event) {
         event.close();
-        socketChannel!.sink.close(ws_status.goingAway);
-        _connectionStateController.add(SocketConnectionState.notConnected);
+        unawaited(_closeSocketChannel());
       },
     ).listen(null);
+  }
+
+  Future<void> _closeSocketChannel() async {
+    // avoid race condition in onCancel by setting socket connection
+    // state to notConnected prior to closing socket. This ensures we don't
+    // attempt to send a message over the channel that we're closing
+    // if we are forcefully closing the socket
+    if (!_connectionStateController.isClosed &&
+        _connectionStateController.value !=
+            SocketConnectionState.notConnected) {
+      _connectionStateController.add(SocketConnectionState.notConnected);
+    }
+    await socketChannel?.sink.close(ws_status.normalClosure);
   }
 
   /// Connects to the server.
@@ -213,7 +226,7 @@ class SocketClient {
   Future<void> _connect() async {
     final InitOperation initOperation = await config.initOperation;
 
-    if (_connectionStateController.isClosed) {
+    if (_connectionStateController.isClosed || _wasDisposed) {
       return;
     }
 
@@ -250,8 +263,8 @@ class SocketClient {
     }
   }
 
-  void onConnectionLost([e]) {
-    socketChannel?.sink.close(ws_status.goingAway);
+  void onConnectionLost([e]) async {
+    await _closeSocketChannel();
     if (e != null) {
       print('There was an error causing connection lost: $e');
     }
@@ -260,19 +273,16 @@ class SocketClient {
     _keepAliveSubscription?.cancel();
     _messageSubscription?.cancel();
 
-    if (_connectionStateController.isClosed) {
+    if (_connectionStateController.isClosed || _wasDisposed) {
       return;
     }
 
     _connectionWasLost = true;
     _subscriptionInitializers.values.forEach((s) => s.hasBeenTriggered = false);
 
-    if (_connectionStateController.value !=
-        SocketConnectionState.notConnected) {
-      _connectionStateController.add(SocketConnectionState.notConnected);
-    }
-
-    if (config.autoReconnect && !_connectionStateController.isClosed) {
+    if (config.autoReconnect &&
+        !_connectionStateController.isClosed &&
+        !_wasDisposed) {
       if (config.delayBetweenReconnectionAttempts != null) {
         _reconnectTimer = Timer(
           config.delayBetweenReconnectionAttempts!,
@@ -293,11 +303,15 @@ class SocketClient {
   /// Use this method if you'd like to disconnect from the specified server permanently,
   /// and you'd like to connect to another server instead of the current one.
   Future<void> dispose() async {
+    // Make sure we do not attempt to reconnect when we close the socket
+    // and onConnectionLost is called (as part of onDone)
+    _wasDisposed = true;
     print('Disposing socket client..');
     _reconnectTimer?.cancel();
+    _keepAliveSubscription?.cancel();
 
     await Future.wait([
-      socketChannel?.sink.close(ws_status.goingAway),
+      _closeSocketChannel(),
       _messageSubscription?.cancel(),
       _connectionStateController.close(),
     ].where((future) => future != null).cast<Future<dynamic>>().toList());
@@ -375,7 +389,7 @@ class SocketClient {
 
             return false;
           },
-        ).takeWhile((_) => !response.isClosed);
+        ).takeWhile((_) => (!response.isClosed && !_wasDisposed));
 
         final Stream<GraphQLSocketMessage> subscriptionComplete = addTimeout
             ? dataErrorComplete

--- a/packages/graphql/test/mock_server/ws_echo_server.dart
+++ b/packages/graphql/test/mock_server/ws_echo_server.dart
@@ -4,6 +4,8 @@
 /// author: https://github.com/vincenzopalazzo
 import 'dart:io';
 
+const String forceDisconnectCommand = '___force_disconnect___';
+
 /// Main function to create and run the echo server over the web socket.
 Future<String> runWebSocketServer(
     {String host = "127.0.0.1", int port = 5600}) async {
@@ -14,7 +16,11 @@ Future<String> runWebSocketServer(
 
 /// Handle event received on server.
 void onWebSocketData(WebSocket client) {
-  client.listen((data) {
-    client.add(data);
+  client.listen((data) async {
+    if (data != null && data.toString().contains(forceDisconnectCommand)) {
+      client.close(WebSocketStatus.normalClosure, 'shutting down');
+    } else {
+      client.add(data);
+    }
   });
 }

--- a/packages/graphql/test/websocket_test.dart
+++ b/packages/graphql/test/websocket_test.dart
@@ -1,6 +1,7 @@
 //@Skip('currently failing for web socket services unavailable')
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:async/async.dart';
 import 'package:rxdart/subjects.dart';
@@ -87,12 +88,17 @@ class EchoSocket implements WebSocketChannel {
 }
 
 SocketClient getTestClient(
-        {required String wsUrl, StreamController? controller}) =>
+        {required String wsUrl,
+        StreamController? controller,
+        bool autoReconnect = true,
+        Duration delayBetweenReconnectionAttempts =
+            const Duration(milliseconds: 1)}) =>
     SocketClient(
       wsUrl,
       connect: (_, __) => EchoSocket.connect(controller ?? BehaviorSubject()),
       config: SocketClientConfig(
-        delayBetweenReconnectionAttempts: Duration(milliseconds: 1),
+        autoReconnect: autoReconnect,
+        delayBetweenReconnectionAttempts: delayBetweenReconnectionAttempts,
       ),
       randomBytesForUuid: Uint8List.fromList(
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
@@ -159,6 +165,47 @@ Future<void> main() async {
         ),
       );
     });
+    test('disconnect via dispose', () async {
+      // First wait for connection to complete
+      await expectLater(
+        socketClient.connectionState.asBroadcastStream(),
+        emitsInOrder(
+          [
+            SocketConnectionState.connecting,
+            SocketConnectionState.connected,
+          ],
+        ),
+      );
+
+      // We need to begin waiting on the connectionState
+      // before we issue the command to disconnect; otherwise
+      // it can reconnect so fast that it will be reconnected
+      // by the time that the expectLater check is initiated.
+      await overridePrint((_) async {
+        Timer(const Duration(milliseconds: 20), () async {
+          await socketClient.dispose();
+        });
+      })();
+      // The connectionState BehaviorController emits the current state
+      // to any new listener, so we expect it to start in the connected
+      // state and transition to notConnected because of dispose.
+      await expectLater(
+        socketClient.connectionState,
+        emitsInOrder([
+          SocketConnectionState.connected,
+          SocketConnectionState.notConnected,
+        ]),
+      );
+
+      // Have to wait for socket close to be fully processed after we reach
+      // the notConnected state, including updating channel with close code.
+      await Future.delayed(const Duration(milliseconds: 20));
+
+      // The websocket should be in a fully closed state at this point,
+      // we should have a confirmed close code in the channel.
+      expect(socketClient.socketChannel, isNotNull);
+      expect(socketClient.socketChannel!.closeCode, isNotNull);
+    });
     test('subscription data', () async {
       final payload = Request(
         operation: Operation(document: parseString('subscription {}')),
@@ -217,7 +264,9 @@ Future<void> main() async {
         ]),
       );
 
-      socketClient.onConnectionLost();
+      await overridePrint((_) async {
+        socketClient.onConnectionLost();
+      })();
 
       await expectLater(
         socketClient.connectionState,
@@ -258,6 +307,117 @@ Future<void> main() async {
           ),
         ),
       );
+    });
+    test('resubscribe after server disconnect', () async {
+      final payload = Request(
+        operation: Operation(document: gql('subscription {}')),
+      );
+      final waitForConnection = true;
+      final subscriptionDataStream =
+          socketClient.subscribe(payload, waitForConnection);
+
+      await expectLater(
+        socketClient.connectionState,
+        emitsInOrder([
+          SocketConnectionState.connecting,
+          SocketConnectionState.connected,
+        ]),
+      );
+
+      // We need to begin waiting on the connectionState
+      // before we issue the command to disconnect; otherwise
+      // it can reconnect so fast that it will be reconnected
+      // by the time that the expectLater check is initiated.
+      Timer(const Duration(milliseconds: 20), () async {
+        socketClient.socketChannel!.sink.add(forceDisconnectCommand);
+      });
+      // The connectionState BehaviorController emits the current state
+      // to any new listener, so we expect it to start in the connected
+      // state, transition to notConnected, and then reconnect after that.
+      await expectLater(
+        socketClient.connectionState,
+        emitsInOrder([
+          SocketConnectionState.connected,
+          SocketConnectionState.notConnected,
+          SocketConnectionState.connecting,
+          SocketConnectionState.connected,
+        ]),
+      );
+
+      // ignore: unawaited_futures
+      socketClient.socketChannel!.stream
+          .where((message) => message == expectedMessage)
+          .first
+          .then((_) {
+        socketClient.socketChannel!.sink.add(jsonEncode({
+          'type': 'data',
+          'id': '01020304-0506-4708-890a-0b0c0d0e0f10',
+          'payload': {
+            'data': {'foo': 'bar'},
+            'errors': [
+              {'message': 'error and data can coexist'}
+            ]
+          }
+        }));
+      });
+
+      await expectLater(
+        subscriptionDataStream,
+        emits(
+          // todo should ids be included in response context? probably '01020304-0506-4708-890a-0b0c0d0e0f10'
+          Response(
+            data: {'foo': 'bar'},
+            errors: [
+              GraphQLError(message: 'error and data can coexist'),
+            ],
+            context: Context().withEntry(ResponseExtensions(null)),
+          ),
+        ),
+      );
+    });
+  }, tags: "integration");
+
+  group('SocketClient without autoReconnect', () {
+    late SocketClient socketClient;
+    StreamController controller;
+    setUp(overridePrint((log) {
+      controller = StreamController(sync: true);
+      socketClient = getTestClient(
+          controller: controller, wsUrl: wsUrl, autoReconnect: false);
+    }));
+    tearDown(overridePrint(
+      (log) => socketClient.dispose(),
+    ));
+    test('server disconnect', () async {
+      final payload = Request(
+        operation: Operation(document: gql('subscription {}')),
+      );
+      final waitForConnection = true;
+      socketClient.subscribe(payload, waitForConnection);
+
+      await expectLater(
+        socketClient.connectionState,
+        emitsInOrder([
+          SocketConnectionState.connecting,
+          SocketConnectionState.connected,
+        ]),
+      );
+
+      Timer(const Duration(milliseconds: 20), () async {
+        socketClient.socketChannel!.sink.add(forceDisconnectCommand);
+      });
+      // Same strategy as elsewhere, start expecting the state on the
+      // stream before the disconnect actually happens...
+      await expectLater(
+        socketClient.connectionState,
+        emitsInOrder([
+          SocketConnectionState.connected,
+          SocketConnectionState.notConnected,
+        ]),
+      );
+
+      expect(
+          socketClient.socketChannel!.closeCode, WebSocketStatus.normalClosure);
     });
   }, tags: "integration");
 


### PR DESCRIPTION
Fixes https://github.com/zino-hofmann/graphql-flutter/issues/968 by using `ws_status.normalClosure` instead of `ws_status.goingAway`

Some additional issues were encountered based on some manual testing of graceful and forced websocket disconnects under different conditions on the web platform, so this PR also fixes these as well:
* Solves a race condition when the websocket was programmatically closed where if the `onCancel` callback was called before the socket connection state was set to `notConnected`, it was trying to send a "shutdown" message on the now-closed socket, causing an exception. This is solved by always setting the connection state to `notConnected` before the websocket is programmatically closed.
* A race condition existed in the dispose call if onConnectionLost was called before the connectionStateController was caused, and autoReconnect was true -- it could lead to a situation where it was trying to reconnect the socket during the dispose call after it just had shut down the websocket. This is solved by the combination of the solution to the previous race condition, as well as a new variable that explicitly indicates that the `SocketClient` has been disposed and it should no longer attempt to reconnect or do other similar work.
* Fixed a bug where the connection would not automatically reconnect even if autoReconnect was true if it was the server that had forcefully disconnected the websocket (e.g., the GraphQL server had shut down). This was fixed by setting `cancelOnError` on the `_messages` stream to false, so that it will properly call the `onDone` callback (triggers `onConnectionLost`, which triggers the reconnect). Looking at the blame history, `cancelOnError` was set to true from the beginning, it's not clear why this was, but it seems like there is no other unanticipated side effect of this change.

This was manually tested on the web platform that websockets are now cleanly closed without exception, that no reconnect attempt is ever made during an explicit dispose of the `WebSocketLink`, and that reconnection attempts will continue to happen (if configured) until a connection is successfully made.

This might help with https://github.com/zino-hofmann/graphql-flutter/issues/873 but I don't know for sure if the issue described there is for sure related to any of the above.