### PR TITLE
fix: Pass parse type to run

### DIFF
--- a/packages/graphql_flutter/lib/src/widgets/mutation.dart
+++ b/packages/graphql_flutter/lib/src/widgets/mutation.dart
@@ -10,7 +10,7 @@ typedef RunMutation<TParsed> = MultiSourceResult<TParsed> Function(
 });
 
 typedef MutationBuilder<TParsed> = Widget Function(
-  RunMutation runMutation,
+  RunMutation<TParsed> runMutation,
   QueryResult<TParsed>? result,
 );
 


### PR DESCRIPTION
I forgot to parse the `TParsed` to the runner in the `MutationBuilder`.

