### PR TITLE
fix: Make the graphql version specific

### DIFF
--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -3,7 +3,7 @@ description: A GraphQL client for Flutter, bringing all the features from a mode
 version: 5.0.2-beta.1
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql_flutter
 dependencies:
-  graphql: ^5.0.1-beta.5
+  graphql: 5.0.1
   gql_exec: 0.3.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
Until we've separated the releases of the two packages, the dependency should be set to a specific version

Describe the purpose of the pull request.
