### PR TITLE
fix: Cache-reboardcast error

### DIFF
--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'package:graphql/client.dart';
+import 'package:graphql/src/utilities/response.dart';
 import 'package:meta/meta.dart';
 
 import 'package:graphql/src/core/fetch_more.dart';
@@ -228,6 +229,17 @@ class ObservableQuery<TParsed> {
       queryManager: queryManager,
       previousResult: latestResult!,
       queryId: queryId,
+    );
+  }
+
+  void addFetchResult(
+    Response response,
+    QueryResultSource source, {
+    bool fromRebroadcast = false,
+  }) {
+    addResult(
+      mapFetchResultToQueryResult<TParsed>(response, options, source: source),
+      fromRebroadcast: fromRebroadcast,
     );
   }
 

--- a/packages/graphql/lib/src/utilities/response.dart
+++ b/packages/graphql/lib/src/utilities/response.dart
@@ -1,0 +1,44 @@
+import 'package:graphql/src/core/_base_options.dart';
+import 'package:graphql/src/core/core.dart';
+import 'package:graphql/src/exceptions.dart';
+
+QueryResult<TParsed> mapFetchResultToQueryResult<TParsed>(
+  Response response,
+  BaseOptions<TParsed> options, {
+  required QueryResultSource source,
+}) {
+  List<GraphQLError>? errors;
+  dynamic data;
+
+  // check if there are errors and apply the error policy if so
+  // in a nutshell: `ignore` swallows errors, `none` swallows data
+  if (response.errors != null && response.errors!.isNotEmpty) {
+    switch (options.errorPolicy) {
+      case ErrorPolicy.all:
+        // handle both errors and data
+        errors = response.errors;
+        data = response.data;
+        break;
+      case ErrorPolicy.ignore:
+        // ignore errors
+        data = response.data;
+        break;
+      case ErrorPolicy.none:
+      default:
+        // TODO not actually sure if apollo even casts graphql errors in `none` mode,
+        // it's also kind of legacy
+        errors = response.errors;
+        break;
+    }
+  } else {
+    data = response.data;
+  }
+
+  return QueryResult(
+    data: data,
+    context: response.context,
+    source: source,
+    exception: coalesceErrors(graphqlErrors: errors),
+    parserFn: options.parserFn,
+  );
+}


### PR DESCRIPTION
With the introduction of `parserFn` we can annotate parsed type on the `QueryResult`. When rebroadcasting, the generic is lost which causes the error:

```
[VERBOSE-2:ui_dart_state.cc(209)] Unhandled Exception: type 'QueryResult<dynamic>' is not a subtype of type 'QueryResult<QueryFetchLibrary>' of 'result'
#0      ObservableQuery.addResult (package:graphql[/src/core/observable_query.dart]())
package:graphql/…/core/observable_query.dart:1
#1      QueryManager.maybeRebroadcastQueries
package:graphql/…/core/query_manager.dart:468
#2      ObservableQuery._maybeRebroadcast
package:graphql/…/core/observable_query.dart:94
#3      ObservableQuery._applyCallbacks
package:graphql/…/core/observable_query.dart:292
#4      ObservableQuery.addResult
package:graphql/…/core/observable_query.dart:264
#5      QueryManager.addQueryResult
package:graphql/…/core/query_manager.dart:402
#6      QueryManager._resolveQueryOnNetwork
package:graphql/…/core/query_manager.dart:276
<asynchronous suspension>
```

This means that cache updates won't propagate.

This PR refactors the code to preserve type information.

**TODO**

- [ ] Let's add a test illustrating this.