### PR TITLE
fix: Fetch more is broken with `parserFn`

### DIFF
--- a/packages/graphql/lib/src/core/fetch_more.dart
+++ b/packages/graphql/lib/src/core/fetch_more.dart
@@ -21,18 +21,10 @@ Future<QueryResult<TParsed>> fetchMoreImplementation<TParsed>(
 }) async {
   // fetch more and update
 
-  final document = (fetchMoreOptions.document ?? originalOptions.document);
   final request = originalOptions.asRequest;
 
-  final combinedOptions = QueryOptions<TParsed>(
-    fetchPolicy: FetchPolicy.noCache,
-    errorPolicy: originalOptions.errorPolicy,
-    document: document,
-    variables: {
-      ...originalOptions.variables,
-      ...fetchMoreOptions.variables,
-    },
-  );
+  final combinedOptions =
+      originalOptions.withFetchMoreOptions(fetchMoreOptions);
 
   QueryResult<TParsed> fetchMoreResult =
       await queryManager.query(combinedOptions);

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -1,3 +1,4 @@
+import 'package:gql/language.dart';
 import 'package:graphql/src/core/_base_options.dart';
 import 'package:graphql/src/core/result_parser.dart';
 import 'package:graphql/src/utilities/helpers.dart';
@@ -42,6 +43,22 @@ class QueryOptions<TParsed> extends BaseOptions<TParsed> {
         pollInterval,
       ];
 
+  QueryOptions<TParsed> withFetchMoreOptions(
+    FetchMoreOptions fetchMoreOptions,
+  ) =>
+      QueryOptions<TParsed>(
+        document: fetchMoreOptions.document ?? document,
+        operationName: operationName,
+        fetchPolicy: FetchPolicy.noCache,
+        errorPolicy: errorPolicy,
+        parserFn: parserFn,
+        context: context,
+        variables: {
+          ...variables,
+          ...fetchMoreOptions.variables,
+        },
+      );
+
   WatchQueryOptions<TParsed> asWatchQueryOptions({bool fetchResults = true}) =>
       WatchQueryOptions(
         document: document,
@@ -54,7 +71,7 @@ class QueryOptions<TParsed> extends BaseOptions<TParsed> {
         fetchResults: fetchResults,
         context: context,
         optimisticResult: optimisticResult,
-        parserFn: this.parserFn,
+        parserFn: parserFn,
       );
 
   QueryOptions<TParsed> copyWithPolicies(Policies policies) => QueryOptions(


### PR DESCRIPTION
It was raised in https://github.com/heftapp/graphql_codegen/issues/41 that the `fetchMore` throws an error when using `graphql_codegen` (i.e. `parserFn`). It is because we're creating the fetch-more `QueryOptions` without passing the `parserFn`. This PR fixes this.
