### PR TITLE
doc: update the graphql doc regarding the custom headers

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -329,10 +329,16 @@ connect: (url, protocols) {
 }
 ```
 
-To supply custom headers to an IO client:
+To supply custom headers (not supported on Flutter Web):
 ```dart
-connect: (url, protocols) =>
-  IOWebSocketChannel.connect(url, protocols: protocols, headers: myCustomHeaders)
+ SocketClient(
+    wsUrl,
+    config: SocketClientConfig(
+      autoReconnect: autoReconnect,
+      headers: customHeaders,
+      delayBetweenReconnectionAttempts: delayBetweenReconnectionAttempts,
+    ),
+ );
 ```
 
 ### `client.watchQuery` and `ObservableQuery`


### PR DESCRIPTION
I noted that I forgot to update the doc regarding the custom headers