### PR TITLE
Add pedantic

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:collection';
 import 'dart:convert';
 import 'dart:typed_data';
+import 'package:pedantic/pedantic.dart';
 
 import 'package:graphql/src/links/gql_links.dart';
 import 'package:graphql/src/utilities/platform.dart';

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   stream_channel: ^2.1.0
   rxdart: ^0.27.1
   uuid: ^3.0.1
+  pedantic:
 dev_dependencies:
   async: ^2.5.0
   mockito: ^5.0.0


### PR DESCRIPTION
This merge request fix `unawait` is not defined on Flutter 2.2.3 and Dark SDK >=2.7.0 <3.0.0
### Breaking changes

- Broke ... because ... .

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated ... .

#### Docs

- Added ... .
- Updated ... .
