### PR TITLE
bugfix/polling-type-mismatch

### DIFF
--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -344,7 +344,7 @@ class ObservableQuery<TParsed> {
 
     options = options.copyWithPollInterval(pollInterval);
     lifecycle = QueryLifecycle.polling;
-    scheduler!.startPollingQuery(options, queryId);
+    scheduler!.startPollingQuery<TParsed>(options, queryId);
   }
 
   void stopPolling() {

--- a/packages/graphql/lib/src/scheduler/scheduler.dart
+++ b/packages/graphql/lib/src/scheduler/scheduler.dart
@@ -23,7 +23,7 @@ class QueryScheduler {
   /// Map going from polling interval durations to polling timers.
   final Map<Duration?, Timer> _pollingTimers = <Duration?, Timer>{};
 
-  void fetchQueriesOnInterval(
+  void fetchQueriesOnInterval<TParsed>(
     Timer timer,
     Duration? interval,
   ) {
@@ -57,11 +57,12 @@ class QueryScheduler {
     }
 
     // fetch each query on the interval
-    intervalQueries[interval]!.forEach(queryManager!.refetchQuery);
+    intervalQueries[interval]!
+        .forEach((e) => queryManager!.refetchQuery<TParsed>(e));
   }
 
-  void startPollingQuery(
-    WatchQueryOptions options,
+  void startPollingQuery<TParsed>(
+    WatchQueryOptions<TParsed> options,
     String queryId,
   ) {
     assert(
@@ -79,7 +80,7 @@ class QueryScheduler {
 
       _pollingTimers[interval] = Timer.periodic(
         interval!,
-        (Timer timer) => fetchQueriesOnInterval(timer, interval),
+        (Timer timer) => fetchQueriesOnInterval<TParsed>(timer, interval),
       );
     }
   }


### PR DESCRIPTION
Hi @budde377 @vincenzopalazzo 

I had some errors in console so I did this PR to help you with evolving the package

#### Fixes / Enhancements

- Fixed type error while using `pollInterval`

If try to use `pollInterval` option you'll get the error in console

```
flutter: Caught error: type 'QueryResult<dynamic>' is not a subtype of type 'QueryResult<Tickets$Query>' of 'result'
flutter: #0      ObservableQuery.addResult (package:graphql/src/core/observable_query.dart)
#1      QueryManager.addQueryResult (package:graphql/src/core/query_manager.dart:393:23)
#2      QueryManager._resolveQueryOnNetwork (package:graphql/src/core/query_manager.dart:265:7)
<asynchronous suspension>
```