### PR TITLE
fix: create results from options

### DIFF
--- a/.github/workflows/graphql_build.yml
+++ b/.github/workflows/graphql_build.yml
@@ -11,15 +11,6 @@ jobs:
         with:
           sdk: stable
       - name: Install dependencies
-        run: |
-          cd packages/graphql
-          dart pub get
+        run: make dep
       - name: Code formatting check
-        run: |
-          cd packages/graphql
-          dart format --set-exit-if-changed .
-      - name: Code analyze check
-        run: |
-          cd packages/graphql
-          dart analyze lib --fatal-infos
-          dart analyze test --fatal-infos
+        run: make ci_fmt_client

--- a/.github/workflows/graphql_build.yml
+++ b/.github/workflows/graphql_build.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@v1
         with:
-          sdk: stable
+          channel: 'stable'
       - name: Install dependencies
         run: make dep
       - name: Code formatting check

--- a/.github/workflows/graphql_codcoverage.yml
+++ b/.github/workflows/graphql_codcoverage.yml
@@ -13,10 +13,8 @@ jobs:
           sdk: stable
       - name: Run tests with coverage
         run: |
-          cd packages/graphql
-          dart pub get
-          dart run test --coverage="coverage"
-          dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib
+          make dep
+          make ci_coverage_client
       - name: Upload coverage file
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/.github/workflows/graphql_codcoverage.yml
+++ b/.github/workflows/graphql_codcoverage.yml
@@ -8,9 +8,9 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@v1
         with:
-          sdk: stable
+          channel: 'stable'
       - name: Run tests with coverage
         run: |
           make dep

--- a/.github/workflows/graphql_flutter_build.yml
+++ b/.github/workflows/graphql_flutter_build.yml
@@ -4,19 +4,11 @@ on: [ push, pull_request ]
 
 jobs:
   build:
-    # This job will run on ubuntu virtual machine
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: subosito/flutter-action@v1
         with:
           channel: 'stable'
-      - run: |
-          cd packages/graphql_flutter
-          flutter pub get
-      - run: |
-          cd packages/graphql_flutter
-          flutter format --set-exit-if-changed .
-      - run: |
-          cd packages/graphql_flutter
-          flutter analyze . --fatal-infos
+      - run: make dep
+      - run: make ci_fmt_flutter

--- a/.github/workflows/graphql_flutter_codcoverage.yml
+++ b/.github/workflows/graphql_flutter_codcoverage.yml
@@ -11,7 +11,6 @@ jobs:
         with:
           channel: 'stable'
       - run: |
-          cd packages/graphql_flutter
           make dep
           make ci_coverage_flutter
       - name: Upload coverage file

--- a/.github/workflows/graphql_flutter_codcoverage.yml
+++ b/.github/workflows/graphql_flutter_codcoverage.yml
@@ -12,8 +12,8 @@ jobs:
           channel: 'stable'
       - run: |
           cd packages/graphql_flutter
-          flutter pub get
-          flutter test --coverage
+          make dep
+          make ci_coverage_flutter
       - name: Upload coverage file
         run: |
           curl -Os https://uploader.codecov.io/latest/linux/codecov

--- a/.github/workflows/graphql_flutter_tests.yml
+++ b/.github/workflows/graphql_flutter_tests.yml
@@ -11,9 +11,7 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: 'stable'
-      - run: |
-          cd packages/graphql_flutter
-          flutter pub get
-      - run: |
-          cd packages/graphql_flutter
-          flutter test .
+      - name: Install dependencies
+        run: make dep
+      -  name: Tests
+      - run: make ci_check_flutter

--- a/.github/workflows/graphql_tests.yml
+++ b/.github/workflows/graphql_tests.yml
@@ -11,10 +11,6 @@ jobs:
         with:
           sdk: stable
       - name: Install dependencies
-        run: |
-          cd packages/graphql
-          dart pub get
-      - name: Code formatting check
-        run: |
-          cd packages/graphql
-          dart test .
+        run: make dep
+      - name: Tests
+        run: make ci_check_client

--- a/.github/workflows/graphql_tests.yml
+++ b/.github/workflows/graphql_tests.yml
@@ -7,9 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v1
+      - uses: subosito/flutter-action@v1
         with:
-          sdk: stable
+          channel: 'stable'
       - name: Install dependencies
         run: make dep
       - name: Tests

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,12 @@ ci_fmt_client:
 ci_fmt_flutter:
 	$(CC) run client_analyze --no-select
 
+ci_coverage_client:
+	$(CC) run client_test_coverage --no-select
+
+ci_coverage_flutter:
+	$(CC) run flutter_test_coverage --no-select
+
 check_client: ci_fmt_client ci_check_client
 
 check_flutter: ci_fmt_flutter ci_check_flutter

--- a/examples/starwars/pubspec.yaml
+++ b/examples/starwars/pubspec.yaml
@@ -9,8 +9,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  graphql_flutter: 5.0.1
-  graphql: 5.0.1
+  graphql_flutter:
+    path: ../../packages/graphql_flutter
+  graphql:
+    path: ../../packages/graphql
   universal_platform:
     ^0.1.3
     # https://github.com/flutter/flutter/issues/36126#issuecomment-596215587

--- a/melos.yaml
+++ b/melos.yaml
@@ -53,4 +53,24 @@ scripts:
     env:
       MELOS_TEST: true
 
+  flutter_test_coverage:
+    description: Run tests in a specific package.
+    run: melos exec --depends-on="graphql" --concurrency=2 -- "flutter test --coverage"
+    select-package:
+      scope: "graphql_flutter"
+      dir-exists:
+        - "test/"
+    env:
+      MELOS_TEST: true
+
+  client_test_coverage:
+    description: Run tests in a specific package.
+    run: melos exec --concurrency=2 -- "dart run test --coverage="coverage" && dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib"
+    select-package:
+      scope: "graphql"
+      dir-exists:
+        - "test/"
+    env:
+      MELOS_TEST: true
+
   format: dart format -o write .

--- a/packages/graphql/lib/src/cache/hive_store.dart
+++ b/packages/graphql/lib/src/cache/hive_store.dart
@@ -28,6 +28,9 @@ class HiveStore extends Store {
   }) async =>
       HiveStore(await openBox(boxName: boxName, path: path));
 
+  /// Init Hive on specific Path
+  static void init({required String onPath}) => Hive.init(onPath);
+
   /// Direct access to the underlying [Box].
   ///
   /// **WARNING**: Directly editing the contents of the store will not automatically

--- a/packages/graphql/lib/src/cache/hive_store.dart
+++ b/packages/graphql/lib/src/cache/hive_store.dart
@@ -13,7 +13,10 @@ class HiveStore extends Store {
   /// Opens a box. Convenience pass through to [Hive.openBox].
   ///
   /// If the box is already open, the instance is returned and all provided parameters are being ignored.
-  static final openBox = Hive.openBox;
+  static Future<Box<Map<String, dynamic>>> openBox(
+      {required String boxName, String? path}) async {
+    return await Hive.openBox<Map<String, dynamic>>(boxName, path: path);
+  }
 
   /// Convenience factory for `HiveStore(await openBox(boxName ?? 'graphqlClientStore', path: path))`
   ///
@@ -23,7 +26,7 @@ class HiveStore extends Store {
     String boxName = defaultBoxName,
     String? path,
   }) async =>
-      HiveStore(await openBox(boxName, path: path));
+      HiveStore(await openBox(boxName: boxName, path: path));
 
   /// Direct access to the underlying [Box].
   ///
@@ -31,14 +34,14 @@ class HiveStore extends Store {
   /// rebroadcast operations.
   final Box<Map<String, dynamic>?> box;
 
-  /// Creates a HiveStore inititalized with the given [box], defaulting to `Hive.box(defaultBoxName)`
+  /// Creates a HiveStore initialized with the given [box], defaulting to `Hive.box(defaultBoxName)`
   ///
   /// **N.B.**: [box] must already be [opened] with either [openBox], [open], or `initHiveForFlutter` from `graphql_flutter`.
   /// This lets us decouple the async initialization logic, making store usage elsewhere much more straightforward.
   ///
   /// [opened]: https://docs.hivedb.dev/#/README?id=open-a-box
-  HiveStore([Box<Map<String, dynamic>?>? box])
-      : this.box = box ?? Hive.box(defaultBoxName);
+  HiveStore([Box<Map<String, dynamic>>? box])
+      : this.box = box ?? Hive.box<Map<String, dynamic>>(defaultBoxName);
 
   @override
   Map<String, dynamic>? get(String dataId) {

--- a/packages/graphql/lib/src/core/_base_options.dart
+++ b/packages/graphql/lib/src/core/_base_options.dart
@@ -115,4 +115,18 @@ abstract class BaseOptions<TParsed extends Object?> {
   int get hashCode => const ListEquality<Object?>(
         DeepCollectionEquality(),
       ).hash(properties);
+
+  QueryResult<TParsed> createResult({
+    Map<String, dynamic>? data,
+    OperationException? exception,
+    Context context = const Context(),
+    required QueryResultSource source,
+  }) =>
+      QueryResult.internal(
+        parserFn: parserFn,
+        data: data,
+        exception: exception,
+        context: context,
+        source: source,
+      );
 }

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:graphql/client.dart';
-import 'package:graphql/src/utilities/response.dart';
 import 'package:meta/meta.dart';
 
 import 'package:graphql/src/core/fetch_more.dart';
@@ -133,7 +132,7 @@ class ObservableQuery<TParsed> {
     if (isRefetchSafe) {
       addResult(QueryResult.loading(
         data: latestResult?.data,
-        parserFn: options.parserFn,
+        options: options,
       ));
       return await queryManager.refetchQuery<TParsed>(queryId);
     }
@@ -220,7 +219,7 @@ class ObservableQuery<TParsed> {
       FetchMoreOptions fetchMoreOptions) async {
     addResult(QueryResult.loading(
       data: latestResult?.data,
-      parserFn: options.parserFn,
+      options: options,
     ));
 
     return fetchMoreImplementation(
@@ -229,17 +228,6 @@ class ObservableQuery<TParsed> {
       queryManager: queryManager,
       previousResult: latestResult!,
       queryId: queryId,
-    );
-  }
-
-  void addFetchResult(
-    Response response,
-    QueryResultSource source, {
-    bool fromRebroadcast = false,
-  }) {
-    addResult(
-      mapFetchResultToQueryResult<TParsed>(response, options, source: source),
-      fromRebroadcast: fromRebroadcast,
     );
   }
 

--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:graphql/src/core/result_parser.dart';
 import 'package:graphql/src/utilities/response.dart';
 import 'package:meta/meta.dart';
 import 'package:collection/collection.dart';
@@ -76,7 +75,7 @@ class QueryManager {
       // TODO optimisticResults for streams just skip the cache for now
       yield QueryResult.optimistic(
         data: options.optimisticResult as Map<String, dynamic>?,
-        parserFn: options.parserFn,
+        options: options,
       );
     } else if (shouldRespondEagerlyFromCache(options.fetchPolicy)) {
       final cacheResult = cache.readQuery(
@@ -85,9 +84,9 @@ class QueryManager {
       );
       if (cacheResult != null) {
         yield QueryResult(
+          options: options,
           source: QueryResultSource.cache,
           data: cacheResult,
-          parserFn: options.parserFn,
         );
       }
     }
@@ -114,8 +113,8 @@ class QueryManager {
             } catch (failure, trace) {
               // we set the source to indicate where the source of failure
               queryResult ??= QueryResult(
+                options: options,
                 source: QueryResultSource.network,
-                parserFn: options.parserFn,
               );
 
               queryResult.exception = coalesceErrors(
@@ -133,9 +132,9 @@ class QueryManager {
           })
           .transform<QueryResult<TParsed>>(StreamTransformer.fromHandlers(
             handleError: (err, trace, sink) => sink.add(_wrapFailure(
+              options,
               err,
               trace,
-              options.parserFn,
             )),
           ))
           .map((QueryResult<TParsed> queryResult) {
@@ -145,9 +144,9 @@ class QueryManager {
     } catch (ex, trace) {
       yield* Stream.fromIterable([
         _wrapFailure(
+          options,
           ex,
           trace,
-          options.parserFn,
         )
       ]);
     }
@@ -222,7 +221,7 @@ class QueryManager {
     // _resolveQueryEagerly handles cacheOnly,
     // so if we're loading + cacheFirst we continue to network
     return MultiSourceResult(
-      parserFn: options.parserFn,
+      options: options,
       eagerResult: eagerResult,
       networkResult:
           (shouldStopAtCache(options.fetchPolicy) && !eagerResult.isLoading)
@@ -262,8 +261,8 @@ class QueryManager {
     } catch (failure, trace) {
       // we set the source to indicate where the source of failure
       queryResult ??= QueryResult(
+        options: options,
         source: QueryResultSource.network,
-        parserFn: options.parserFn,
       );
 
       queryResult.exception = coalesceErrors(
@@ -295,9 +294,7 @@ class QueryManager {
     String queryId,
     BaseOptions<TParsed> options,
   ) {
-    QueryResult<TParsed> queryResult = QueryResult.loading(
-      parserFn: options.parserFn,
-    );
+    QueryResult<TParsed> queryResult = QueryResult.loading(options: options);
 
     try {
       if (options.optimisticResult != null) {
@@ -317,17 +314,17 @@ class QueryManager {
         // we only push an eager query with data
         if (data != null) {
           queryResult = QueryResult(
+            options: options,
             data: data,
             source: QueryResultSource.cache,
-            parserFn: options.parserFn,
           );
         }
 
         if (options.fetchPolicy == FetchPolicy.cacheOnly &&
             queryResult.isLoading) {
           queryResult = QueryResult(
+            options: options,
             source: QueryResultSource.cache,
-            parserFn: options.parserFn,
             exception: OperationException(
               linkException: CacheMissException(
                 'Could not resolve the given request against the cache. (FetchPolicy.cacheOnly)',
@@ -363,8 +360,7 @@ class QueryManager {
   /// Refetch the [ObservableQuery] referenced by [queryId],
   /// overriding any present non-network-only [FetchPolicy].
   Future<QueryResult<TParsed>?> refetchQuery<TParsed>(String queryId) {
-    WatchQueryOptions<TParsed> options =
-        queries[queryId]!.options as WatchQueryOptions<TParsed>;
+    var options = getQuery<TParsed>(queryId)!.options;
     if (!willAlwaysExecuteOnNetwork(options.fetchPolicy)) {
       options = options.copyWithFetchPolicy(FetchPolicy.networkOnly);
     }
@@ -387,10 +383,13 @@ class QueryManager {
   }
 
   ObservableQuery<Object?>? getQuery(String? queryId) {
-    if (queries.containsKey(queryId)) {
-      return queries[queryId!];
+    if (!queries.containsKey(queryId)) {
+      return null;
     }
-
+    final query = queries[queryId!];
+    if (query is ObservableQuery<TParsed>) {
+      return query;
+    }
     return null;
   }
 
@@ -404,8 +403,7 @@ class QueryManager {
     String? queryId,
     QueryResult<TParsed> queryResult,
   ) {
-    final ObservableQuery<TParsed>? observableQuery =
-        getQuery(queryId) as ObservableQuery<TParsed>?;
+    final observableQuery = getQuery<TParsed>(queryId);
 
     if (observableQuery != null && !observableQuery.controller.isClosed) {
       observableQuery.addResult(queryResult);
@@ -420,8 +418,8 @@ class QueryManager {
     required BaseOptions<TParsed> options,
   }) {
     QueryResult<TParsed> queryResult = QueryResult(
+      options: options,
       source: QueryResultSource.optimisticResult,
-      parserFn: options.parserFn,
     );
 
     attemptCacheWriteFromClient(
@@ -477,9 +475,12 @@ class QueryManager {
           optimistic: query.options.policies.mergeOptimisticData,
         );
         if (_cachedDataHasChangedFor(query, cachedData)) {
-          query.addFetchResult(
-            Response(data: cachedData, response: {}),
-            QueryResultSource.cache,
+          query.addResult(
+            mapFetchResultToQueryResult(
+              Response(data: cachedData, response: {}),
+              query.options,
+              source: QueryResultSource.cache,
+            ),
             fromRebroadcast: true,
           );
         }
@@ -517,13 +518,13 @@ class QueryManager {
 }
 
 QueryResult<TParsed> _wrapFailure<TParsed>(
+  BaseOptions<TParsed> options,
   dynamic ex,
   StackTrace trace,
-  ResultParserFn<TParsed> parserFn,
 ) =>
     QueryResult(
+      options: options,
       // we set the source to indicate where the source of failure
       source: QueryResultSource.network,
       exception: coalesceErrors(linkException: translateFailure(ex, trace)),
-      parserFn: parserFn,
     );

--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -382,7 +382,7 @@ class QueryManager {
     return results;
   }
 
-  ObservableQuery<Object?>? getQuery(String? queryId) {
+  ObservableQuery<TParsed>? getQuery<TParsed>(String? queryId) {
     if (!queries.containsKey(queryId)) {
       return null;
     }

--- a/packages/graphql/lib/src/utilities/response.dart
+++ b/packages/graphql/lib/src/utilities/response.dart
@@ -35,10 +35,10 @@ QueryResult<TParsed> mapFetchResultToQueryResult<TParsed>(
   }
 
   return QueryResult(
+    options: options,
     data: data,
     context: response.context,
     source: source,
     exception: coalesceErrors(graphqlErrors: errors),
-    parserFn: options.parserFn,
   );
 }

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   gql_transform_link: ^0.2.0
   gql_error_link: ^0.2.0
   gql_dedupe_link: ^2.0.0
-  hive: ^2.0.0
+  hive: ^2.1.0
   normalize: ^0.6.0
   http: ^0.13.0
   collection: ^1.15.0

--- a/packages/graphql/test/query_manager_test.dart
+++ b/packages/graphql/test/query_manager_test.dart
@@ -1,0 +1,46 @@
+import 'package:gql/language.dart';
+import 'package:graphql/client.dart';
+import 'package:mockito/mockito.dart';
+import 'package:test/test.dart';
+
+import 'helpers.dart';
+
+void main() {
+  late MockLink link;
+  late GraphQLClient client;
+
+  setUp(() {
+    link = MockLink();
+
+    client = GraphQLClient(
+      cache: getTestCache(),
+      link: link,
+    );
+  });
+
+  group('QueryManager', () {
+    test("Can refetch", () {
+      final response = Response(
+        data: <String, dynamic>{
+          'fetchPerson': null,
+        },
+        response: {},
+      );
+      when(
+        link.request(any),
+      ).thenAnswer(
+        (_) => Stream.fromIterable(
+          [response],
+        ),
+      );
+
+      final observable = client.watchQuery(
+        WatchQueryOptions<String?>(
+          document: parseString("""{ fetchPerson { name } }"""),
+          parserFn: (data) => data['fetchPerson']?['name'] as String?,
+        ),
+      );
+      client.queryManager.refetchQuery(observable.queryId);
+    });
+  });
+}

--- a/packages/graphql/test/query_manager_test.dart
+++ b/packages/graphql/test/query_manager_test.dart
@@ -40,7 +40,7 @@ void main() {
           parserFn: (data) => data['fetchPerson']?['name'] as String?,
         ),
       );
-      client.queryManager.refetchQuery(observable.queryId);
+      client.queryManager.refetchQuery<dynamic>(observable.queryId);
     });
   });
 }

--- a/packages/graphql_flutter/lib/src/hive_init.dart
+++ b/packages/graphql_flutter/lib/src/hive_init.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:flutter/material.dart' show WidgetsFlutterBinding;
 
-import 'package:hive/hive.dart' show Hive;
 import 'package:path_provider/path_provider.dart'
     show getApplicationDocumentsDirectory;
 import 'package:path/path.dart' show join;

--- a/packages/graphql_flutter/lib/src/hive_init.dart
+++ b/packages/graphql_flutter/lib/src/hive_init.dart
@@ -25,9 +25,9 @@ Future<void> initHiveForFlutter(
     if (subDir != null) {
       path = join(path, subDir);
     }
-    Hive.init(path);
+    HiveStore.init(onPath: path);
   }
 
-  final futures = boxes.map(Hive.openBox);
+  final futures = boxes.map((String name) => HiveStore.open(boxName: name));
   await Future.wait(futures);
 }

--- a/packages/graphql_flutter/lib/src/widgets/hooks/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/hooks/subscription.dart
@@ -30,9 +30,9 @@ QueryResult<TParsed> useSubscription<TParsed>(
     initialData: options.optimisticResult != null
         ? QueryResult.optimistic(
             data: options.optimisticResult as Map<String, dynamic>?,
-            parserFn: options.parserFn,
+            options: options,
           )
-        : QueryResult.loading(parserFn: options.parserFn),
+        : QueryResult.loading(options: options),
   );
   return snapshot.data!;
 }

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -2,6 +2,7 @@ name: graphql_flutter
 description: A GraphQL client for Flutter, bringing all the features from a modern GraphQL client to one easy to use package.
 version: 5.0.2-beta.6
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql_flutter
+
 dependencies:
   graphql: ^5.0.2-beta.3
   gql_exec: ^0.4.0
@@ -14,6 +15,7 @@ dependencies:
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
   flutter_hooks: ^0.18.2
+
 dev_dependencies:
   pedantic: ^1.11.0
   mockito: ^5.0.0
@@ -21,5 +23,11 @@ dev_dependencies:
     sdk: flutter
   http: ^0.13.0
   test: ^1.17.12
+
+dependency_overrides:
+  graphql:
+    path: ../graphql
+
 environment:
   sdk: '>=2.12.0 <3.0.0'
+


### PR DESCRIPTION
This PR changes how we create `QueryResults`. By always creating them from a given `BaseOption` we're effectively preserving type information. Losing type context has been the cause of two issues, latest #1072.

Since this PR changes the signature of the `QueryResult` which would warrant a major release if we had a better split of releases. This will cause issues for our beta users. The instruction should be to keep the packages in sync. Again, this is a major argument for persuing split releases.