### PR TITLE
docs: fix typo in websocket connect warning note

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -316,7 +316,7 @@ subscription.listen(reactToAddedReview)
 used to supply custom headers to an IO client, register custom listeners,
 and extract the socket for other non-graphql features.
 
-**Warning:** if you want to listen to the listen to the stream,
+**Warning:** if you want to listen to the stream,
 wrap your channel with our `GraphQLWebSocketChannel` using the `.forGraphQL()` helper:
 ```dart
 connect: (url, protocols) {

--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -84,7 +84,7 @@ class SocketClientConfig {
   /// Useful supplying custom headers to an IO client, registering custom listeners,
   /// and extracting the socket for other non-graphql features.
   ///
-  /// Warning: if you want to listen to the listen to the stream,
+  /// Warning: if you want to listen to the stream,
   /// wrap your channel with our [GraphQLWebSocketChannel] using the `.forGraphQL()` helper:
   /// ```dart
   /// connectFn: (url, protocols) {


### PR DESCRIPTION
#### Docs

- Fixed a typo in the websocket connect warning note

From:
> "listen to the listen to the"

To:
> "listen to the"

Affected Files:
- `/packages/graphql/README.md` : _Line 319_
- `/packages/graphql/lib/src/links/websocket_link/websocket_client.dart` : _Line 87_