### PR TITLE
feat: query onError & onComplete callbacks

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -35,7 +35,7 @@ scripts:
 
   flutter_test:
     description: Run tests in a specific package.
-    run: melos exec --depends-on="graphql" --concurrency=2 -- "flutter pub get && flutter test"
+    run: melos exec --depends-on="graphql" --concurrency=2 -- "flutter test"
     select-package:
       scope: "graphql_flutter"
       dir-exists:

--- a/packages/graphql_flutter/lib/src/widgets/hooks/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/hooks/query.dart
@@ -40,6 +40,15 @@ QueryHookResult<TParsed> useQueryOnClient<TParsed>(
     query.stream,
     initialData: query.latestResult,
   );
+
+  useEffect(() {
+    final cleanup = query.onData(
+      QueryCallbackHandler(options: options).callbacks,
+      removeAfterInvocation: false,
+    );
+    return cleanup;
+  }, [options, query]);
+
   return QueryHookResult(
     result: snapshot.data!,
     refetch: query.refetch,


### PR DESCRIPTION
#### Fixes / Enhancements

Added `onError` & `onCompleted` callbacks to the Query widget and `useQuery` hook. They work pretty much exactly as the same callbacks for Mutations.

Fixes: https://github.com/zino-hofmann/graphql-flutter/issues/954

Let me know if anything needs changing, I'm new to the Dart & Flutter ecosystem, but I'll try my best!