### PR TITLE
feat(graphql_flutter): Decouple GraphQLClient Provider

### DIFF
--- a/packages/graphql_flutter/lib/src/widgets/hooks/mutation.dart
+++ b/packages/graphql_flutter/lib/src/widgets/hooks/mutation.dart
@@ -21,12 +21,19 @@ class MutationHookResult<TParsed> {
 MutationHookResult<TParsed> useMutation<TParsed>(
   MutationOptions<TParsed> options,
 ) {
+  final client = useGraphQLClient();
+  return useMutationOnClient(client, options);
+}
+
+MutationHookResult<TParsed> useMutationOnClient<TParsed>(
+  GraphQLClient client,
+  MutationOptions<TParsed> options,
+) {
   final watchOptions = useMemoized(
     () => options.asWatchQueryOptions(),
     [options],
   );
-  final client = useGraphQLClient();
-  final query = useWatchMutation<TParsed>(watchOptions);
+  final query = useWatchMutationOnClient<TParsed>(client, watchOptions);
   final snapshot = useStream(
     query.stream,
     initialData: query.latestResult ?? QueryResult.unexecuted,

--- a/packages/graphql_flutter/lib/src/widgets/hooks/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/hooks/query.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:graphql/client.dart';
+import 'package:graphql_flutter/src/widgets/hooks/graphql_client.dart';
 import 'package:graphql_flutter/src/widgets/hooks/watch_query.dart';
 
 // method to call from widget to fetchmore queries
@@ -22,11 +23,19 @@ class QueryHookResult<TParsed> {
 }
 
 QueryHookResult<TParsed> useQuery<TParsed>(QueryOptions<TParsed> options) {
+  final client = useGraphQLClient();
+  return useQueryOnClient(client, options);
+}
+
+QueryHookResult<TParsed> useQueryOnClient<TParsed>(
+  GraphQLClient client,
+  QueryOptions<TParsed> options,
+) {
   final watchQueryOptions = useMemoized(
     () => options.asWatchQueryOptions(),
     [options],
   );
-  final query = useWatchQuery(watchQueryOptions);
+  final query = useWatchQueryOnClient(client, watchQueryOptions);
   final snapshot = useStream(
     query.stream,
     initialData: query.latestResult,

--- a/packages/graphql_flutter/lib/src/widgets/hooks/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/hooks/subscription.dart
@@ -20,6 +20,18 @@ QueryResult<TParsed> useSubscription<TParsed>(
   OnSubscriptionResult<TParsed>? onSubscriptionResult,
 }) {
   final client = useGraphQLClient();
+  return useSubscriptionOnClient(
+    client,
+    options,
+    onSubscriptionResult: onSubscriptionResult,
+  );
+}
+
+QueryResult<TParsed> useSubscriptionOnClient<TParsed>(
+  GraphQLClient client,
+  SubscriptionOptions<TParsed> options, {
+  OnSubscriptionResult<TParsed>? onSubscriptionResult,
+}) {
   final stream = use(_SubscriptionHook(
     client: client,
     onSubscriptionResult: onSubscriptionResult,

--- a/packages/graphql_flutter/lib/src/widgets/hooks/watch_query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/hooks/watch_query.dart
@@ -66,6 +66,13 @@ ObservableQuery<TParsed> useWatchQuery<TParsed>(
   WatchQueryOptions<TParsed> options,
 ) {
   final client = useGraphQLClient();
+  return useWatchQueryOnClient(client, options);
+}
+
+ObservableQuery<TParsed> useWatchQueryOnClient<TParsed>(
+  GraphQLClient client,
+  WatchQueryOptions<TParsed> options,
+) {
   final overwrittenOptions = useMemoized(() {
     final policies =
         client.defaultPolicies.query.withOverrides(options.policies);
@@ -79,8 +86,16 @@ ObservableQuery<TParsed> useWatchQuery<TParsed>(
 }
 
 ObservableQuery<TParsed> useWatchMutation<TParsed>(
-    WatchQueryOptions<TParsed> options) {
+  WatchQueryOptions<TParsed> options,
+) {
   final client = useGraphQLClient();
+  return useWatchMutationOnClient(client, options);
+}
+
+ObservableQuery<TParsed> useWatchMutationOnClient<TParsed>(
+  GraphQLClient client,
+  WatchQueryOptions<TParsed> options,
+) {
   final overwrittenOptions = useMemoized(() {
     final policies =
         client.defaultPolicies.mutate.withOverrides(options.policies);

--- a/packages/graphql_flutter/lib/src/widgets/mutation.dart
+++ b/packages/graphql_flutter/lib/src/widgets/mutation.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:graphql/client.dart';
+import 'package:graphql_flutter/src/widgets/hooks/graphql_client.dart';
 import 'package:graphql_flutter/src/widgets/hooks/mutation.dart';
 
 typedef MutationBuilder<TParsed> = Widget Function(
@@ -9,7 +10,7 @@ typedef MutationBuilder<TParsed> = Widget Function(
 );
 
 /// Builds a [Mutation] widget based on the a given set of [MutationOptions]
-/// that streams [QueryResult]s into the [QueryBuilder].
+/// that streams [QueryResult]s into the [MutationBuilder].
 class Mutation<TParsed> extends HookWidget {
   const Mutation({
     final Key? key,
@@ -22,7 +23,32 @@ class Mutation<TParsed> extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final result = useMutation(options);
+    final client = useGraphQLClient();
+    return MutationOnClient(
+      client: client,
+      options: options,
+      builder: builder,
+    );
+  }
+}
+
+/// Builds a [MutationOnClient] widget based on the a given set of [MutationOptions]
+/// that streams [QueryResult]s into the [MutationBuilder].
+class MutationOnClient<TParsed> extends HookWidget {
+  const MutationOnClient({
+    final Key? key,
+    required this.client,
+    required this.options,
+    required this.builder,
+  }) : super(key: key);
+
+  final GraphQLClient client;
+  final MutationOptions<TParsed> options;
+  final MutationBuilder<TParsed> builder;
+
+  @override
+  Widget build(BuildContext context) {
+    final result = useMutationOnClient(client, options);
     return builder(result.runMutation, result.result);
   }
 }

--- a/packages/graphql_flutter/lib/src/widgets/query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/query.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:graphql/client.dart';
+import 'package:graphql_flutter/src/widgets/hooks/graphql_client.dart';
 import 'package:graphql_flutter/src/widgets/hooks/query.dart';
 
 typedef QueryBuilder<TParsed> = Widget Function(
@@ -23,7 +24,32 @@ class Query<TParsed> extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final result = useQuery(options);
+    final client = useGraphQLClient();
+    return QueryOnClient(
+      options: options,
+      builder: builder,
+      client: client,
+    );
+  }
+}
+
+/// Builds a [QueryOnClient] widget based on the a given set of [QueryOptions]
+/// that streams [QueryResult]s into the [QueryBuilder].
+class QueryOnClient<TParsed> extends HookWidget {
+  const QueryOnClient({
+    final Key? key,
+    required this.options,
+    required this.builder,
+    required this.client,
+  }) : super(key: key);
+
+  final GraphQLClient client;
+  final QueryOptions<TParsed> options;
+  final QueryBuilder<TParsed> builder;
+
+  @override
+  Widget build(BuildContext context) {
+    final result = useQueryOnClient(client, options);
     return builder(
       result.result,
       fetchMore: result.fetchMore,

--- a/packages/graphql_flutter/lib/src/widgets/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/subscription.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:graphql/client.dart';
+import 'package:graphql_flutter/src/widgets/hooks/graphql_client.dart';
 import 'package:graphql_flutter/src/widgets/hooks/subscription.dart';
 
 /// Creats a subscription with [GraphQLClient.subscribe].
@@ -67,7 +68,35 @@ class Subscription<TParsed> extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
-    final result = useSubscription<TParsed>(
+    final client = useGraphQLClient();
+    return SubscriptionOnClient(
+      client: client,
+      options: options,
+      builder: builder,
+    );
+  }
+}
+
+/// Creats a subscription widget like [Subscription] but
+/// with an external client.
+class SubscriptionOnClient<TParsed> extends HookWidget {
+  const SubscriptionOnClient({
+    required this.client,
+    required this.options,
+    required this.builder,
+    this.onSubscriptionResult,
+    Key? key,
+  }) : super(key: key);
+
+  final GraphQLClient client;
+  final SubscriptionOptions<TParsed> options;
+  final SubscriptionBuilder<TParsed> builder;
+  final OnSubscriptionResult<TParsed>? onSubscriptionResult;
+
+  @override
+  Widget build(BuildContext context) {
+    final result = useSubscriptionOnClient<TParsed>(
+      client,
       options,
       onSubscriptionResult: onSubscriptionResult,
     );


### PR DESCRIPTION
This PR provides widgets and hooks variants which does not depend on the GraphQL Client Provider (see #640)