### PR TITLE
Fix improve analysis

### DIFF
--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -324,7 +324,7 @@ class FetchMoreOptions {
 }
 
 /// merge fetchMore result data with earlier result data
-typedef Map<String, dynamic>? UpdateQuery(
+typedef UpdateQuery = Map<String, dynamic>? Function(
   Map<String, dynamic>? previousResultData,
   Map<String, dynamic>? fetchMoreResultData,
 );

--- a/packages/graphql/lib/src/utilities/platform_html.dart
+++ b/packages/graphql/lib/src/utilities/platform_html.dart
@@ -7,7 +7,9 @@ Future<WebSocketChannel> defaultConnectPlatform(
   if (headers != null) {
     print("The headers on the web are not supported");
   }
-  final webSocketChannel =
-      await WebSocketChannel.connect(uri, protocols: protocols);
+  final webSocketChannel = WebSocketChannel.connect(
+    uri,
+    protocols: protocols,
+  );
   return webSocketChannel.forGraphQL();
 }

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -27,3 +27,10 @@ dev_dependencies:
 environment:
   sdk: '>=2.12.0 <3.0.0'
 
+platforms:
+  android:
+  ios:
+  linux:
+  macos:
+  web:
+  windows:


### PR DESCRIPTION
This PR fixes a few issues on pub:

* It fixes static analysis bugs which have reduced our pub score by 10 points on `graphql`
* It explicitly adds all supported platforms for `graphql_flutter`. The "web" platform was missing.