### PR TITLE
fix(graphql): Upgrade graphql version

### DIFF
--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -4,7 +4,7 @@ version: 5.1.1-beta.1
 homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql_flutter
 
 dependencies:
-  graphql: ^5.1.1-beta.1
+  graphql: ^5.1.2-beta.1
   gql_exec: ^0.4.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
The package depends on a newer version of graphql for handlers.