### PR TITLE
ci: fixed CI to continue to use flutter 2.x

### DIFF
--- a/.github/workflows/graphql_flutter_build.yml
+++ b/.github/workflows/graphql_flutter_build.yml
@@ -10,5 +10,6 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: 'stable'
+          flutter-version: '2.10.5'
       - run: make dep
       - run: make ci_fmt_flutter

--- a/.github/workflows/graphql_flutter_codcoverage.yml
+++ b/.github/workflows/graphql_flutter_codcoverage.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: 'stable'
+          flutter-version: '2.10.5'
       - run: |
           make dep
           make ci_coverage_flutter

--- a/.github/workflows/graphql_flutter_tests.yml
+++ b/.github/workflows/graphql_flutter_tests.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           channel: 'stable'
+          flutter-version: '2.10.5'
       - name: Install dependencies
         run: make dep
       - name: Tests

--- a/.github/workflows/packages_build.yml
+++ b/.github/workflows/packages_build.yml
@@ -10,6 +10,7 @@ jobs:
       - uses: subosito/flutter-action@v1
         with:
           sdk: stable
+          flutter-version: '2.10.5'
       - name: Install dependencies
         run: make dep
       - name: Code formatting check


### PR DESCRIPTION

New flutter version = graohql flutter new major version?

we, need to discuss a little bit this! for now we fix the github ci to flutter 2.x

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>

<!--
### Breaking changes

- Broke ... because ... .

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated ... .

#### Docs

- Added ... .
- Updated ... .
-->