### PR TITLE
Allow for providing a fetchPolicy to ObservableQuery.fetchResults

### DIFF
--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -182,12 +182,18 @@ class ObservableQuery<TParsed> {
     }
   }
 
-  /// Fetch results based on [options.fetchPolicy]
+  /// Fetch results based on [options.fetchPolicy] by default.
+  ///
+  /// Optionally provide a [fetchPolicy] which will override the
+  /// default [options.fetchPolicy], just for this request.
   ///
   /// Will [startPolling] if [options.pollInterval] is set
-  MultiSourceResult<TParsed> fetchResults() {
+  MultiSourceResult<TParsed> fetchResults({FetchPolicy? fetchPolicy}) {
+    final fetchOptions = fetchPolicy == null 
+      ? options 
+      : options.copyWithFetchPolicy(fetchPolicy);
     final MultiSourceResult<TParsed> allResults =
-        queryManager.fetchQueryAsMultiSourceResult(queryId, options);
+        queryManager.fetchQueryAsMultiSourceResult(queryId, fetchOptions);
     latestResult ??= allResults.eagerResult;
 
     if (allResults.networkResult == null) {
@@ -201,8 +207,8 @@ class ObservableQuery<TParsed> {
           : QueryLifecycle.pending;
     }
 
-    if (options.pollInterval != null && options.pollInterval! > Duration.zero) {
-      startPolling(options.pollInterval);
+    if (fetchOptions.pollInterval != null && fetchOptions.pollInterval! > Duration.zero) {
+      startPolling(fetchOptions.pollInterval);
     }
 
     return allResults;


### PR DESCRIPTION
## Fixes / Enhancements
Added the ability to provide a fetchPolicy to ObservableQuery.fetchResults

### Use case
I'll usually hook up an observable with the `fetchResults` parameter set to false and then periodically call `fetchResults` on it.

```dart
ObservableQuery observableQuery =  client.watchQuery(
      WatchQueryOptions(
        fetchPolicy: fetchPolicy,
        // Tells the watch not to fetch right away. Trigger with `fetchResults`
        fetchResults: false,
        variables: options.variables,
        document: options.document,
      ),
    );

observableQuery.fetchResults();
```

But on subsequent calls to `fetchResults`, I might want to tell it to fetch from network only, cache only, etc. A concrete example being that I'd like to initialize this observable to start with a fetchPolicy of `onlyCache`. Then when the user pulls to refresh, I'd like to trigger `fetchResults(networkOnly)`.

Currently, I'd need to initialize a new observable or use a new async / await call, even though my listener would be the same.

I also might be misusing the library, so please let me know if this makes sense!