### PR TITLE
fix(graphql): send connection_init message during handshake

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -65,7 +65,7 @@ scripts:
 
   client_test_coverage:
     description: Run tests in a specific package.
-    run: melos exec --concurrency=2 -- "dart run test --coverage="coverage" && dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.packages --report-on=lib"
+    run: melos exec --concurrency=2 -- "dart run test --coverage="coverage" && dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.dart_tool/package_config.json --report-on=lib"
     select-package:
       scope: "graphql"
       dir-exists:

--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -370,13 +370,18 @@ class SocketClient {
   }
 
   void _write(final GraphQLSocketMessage message) {
-    if (_connectionStateController.value == SocketConnectionState.connected) {
-      socketChannel!.sink.add(
-        json.encode(
-          message,
-          toEncodable: (dynamic m) => m.toJson(),
-        ),
-      );
+    switch (_connectionStateController.value) {
+      case SocketConnectionState.connected:
+      case SocketConnectionState.handshake:
+        socketChannel!.sink.add(
+          json.encode(
+            message,
+            toEncodable: (dynamic m) => m.toJson(),
+          ),
+        );
+        break;
+      default:
+        break;
     }
   }
 

--- a/packages/graphql/test/websocket_test.dart
+++ b/packages/graphql/test/websocket_test.dart
@@ -12,15 +12,14 @@ import './helpers.dart';
 import './mock_server/ws_echo_server.dart';
 import 'mock_server/ws_echo_server.dart';
 
-SocketClient getTestClient(
-        {required String wsUrl,
-        StreamController<dynamic>? controller,
-        bool autoReconnect = true,
-        Map<String, dynamic>? customHeaders,
-        Duration delayBetweenReconnectionAttempts =
-            const Duration(milliseconds: 1),
-        String protocol = SocketSubProtocol.graphqlWs,
-        }) =>
+SocketClient getTestClient({
+  required String wsUrl,
+  StreamController<dynamic>? controller,
+  bool autoReconnect = true,
+  Map<String, dynamic>? customHeaders,
+  Duration delayBetweenReconnectionAttempts = const Duration(milliseconds: 1),
+  String protocol = SocketSubProtocol.graphqlWs,
+}) =>
     SocketClient(
       wsUrl,
       protocol: protocol,
@@ -340,9 +339,9 @@ Future<void> main() async {
     setUp(overridePrint((log) {
       controller = StreamController(sync: true);
       socketClient = getTestClient(
-          controller: controller,
-          protocol: SocketSubProtocol.graphqlTransportWs,
-          wsUrl: wsUrl,
+        controller: controller,
+        protocol: SocketSubProtocol.graphqlTransportWs,
+        wsUrl: wsUrl,
       );
     }));
     tearDown(overridePrint(

--- a/packages/graphql/test/websocket_test.dart
+++ b/packages/graphql/test/websocket_test.dart
@@ -18,13 +18,19 @@ SocketClient getTestClient(
         bool autoReconnect = true,
         Map<String, dynamic>? customHeaders,
         Duration delayBetweenReconnectionAttempts =
-            const Duration(milliseconds: 1)}) =>
+            const Duration(milliseconds: 1),
+        String protocol = SocketSubProtocol.graphqlWs,
+        }) =>
     SocketClient(
       wsUrl,
+      protocol: protocol,
       config: SocketClientConfig(
         autoReconnect: autoReconnect,
         headers: customHeaders,
         delayBetweenReconnectionAttempts: delayBetweenReconnectionAttempts,
+        initialPayload: {
+          'protocol': protocol,
+        },
       ),
       randomBytesForUuid: Uint8List.fromList(
         [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16],
@@ -313,6 +319,274 @@ Future<void> main() async {
             context: Context().withEntry(ResponseExtensions(null)),
             response: {
               "type": "data",
+              "data": {"foo": "bar"},
+              "errors": [
+                {"message": "error and data can coexist"}
+              ]
+            },
+          ),
+        ),
+      );
+    });
+  }, tags: "integration");
+
+  group('SocketClient without payload graphql-transport-ws', () {
+    late SocketClient socketClient;
+    StreamController<dynamic> controller;
+    final expectedMessage = r'{'
+        r'"type":"subscribe","id":"01020304-0506-4708-890a-0b0c0d0e0f10",'
+        r'"payload":{"operationName":null,"variables":{},"query":"subscription {\n  \n}"}'
+        r'}';
+    setUp(overridePrint((log) {
+      controller = StreamController(sync: true);
+      socketClient = getTestClient(
+          controller: controller,
+          protocol: SocketSubProtocol.graphqlTransportWs,
+          wsUrl: wsUrl,
+      );
+    }));
+    tearDown(overridePrint(
+      (log) => socketClient.dispose(),
+    ));
+    test('connection graphql-transport-ws', () async {
+      await expectLater(
+        socketClient.connectionState.asBroadcastStream(),
+        emitsInOrder(
+          [
+            SocketConnectionState.connecting,
+            SocketConnectionState.handshake,
+            SocketConnectionState.connected,
+          ],
+        ),
+      );
+    });
+    test('disconnect via dispose graphql-transport-ws', () async {
+      // First wait for connection to complete
+      await expectLater(
+        socketClient.connectionState.asBroadcastStream(),
+        emitsInOrder(
+          [
+            SocketConnectionState.connecting,
+            SocketConnectionState.handshake,
+            SocketConnectionState.connected,
+          ],
+        ),
+      );
+
+      // We need to begin waiting on the connectionState
+      // before we issue the command to disconnect; otherwise
+      // it can reconnect so fast that it will be reconnected
+      // by the time that the expectLater check is initiated.
+      await overridePrint((_) async {
+        Timer(const Duration(milliseconds: 20), () async {
+          await socketClient.dispose();
+        });
+      })();
+      // The connectionState BehaviorController emits the current state
+      // to any new listener, so we expect it to start in the connected
+      // state and transition to notConnected because of dispose.
+      await expectLater(
+        socketClient.connectionState,
+        emitsInOrder([
+          SocketConnectionState.connected,
+          SocketConnectionState.notConnected,
+        ]),
+      );
+
+      // Have to wait for socket close to be fully processed after we reach
+      // the notConnected state, including updating channel with close code.
+      await Future<void>.delayed(const Duration(milliseconds: 20));
+
+      // The websocket should be in a fully closed state at this point,
+      // we should have a confirmed close code in the channel.
+      expect(socketClient.socketChannel, isNotNull);
+      expect(socketClient.socketChannel!.closeCode, isNotNull);
+    });
+    test('subscription data graphql-transport-ws', () async {
+      final payload = Request(
+        operation: Operation(document: parseString('subscription {}')),
+      );
+      final waitForConnection = true;
+      final subscriptionDataStream =
+          socketClient.subscribe(payload, waitForConnection);
+      await socketClient.connectionState
+          .where((state) => state == SocketConnectionState.connected)
+          .first;
+
+      // ignore: unawaited_futures
+      socketClient.socketChannel!.stream
+          .where((message) => message == expectedMessage)
+          .first
+          .then((_) {
+        socketClient.socketChannel!.sink.add(jsonEncode({
+          'type': 'next',
+          'id': '01020304-0506-4708-890a-0b0c0d0e0f10',
+          'payload': {
+            'data': {'foo': 'bar'},
+            'errors': [
+              {'message': 'error and data can coexist'}
+            ]
+          }
+        }));
+      });
+
+      await expectLater(
+        subscriptionDataStream,
+        emits(
+          // todo should ids be included in response context? probably '01020304-0506-4708-890a-0b0c0d0e0f10'
+          Response(
+            data: {'foo': 'bar'},
+            errors: [
+              GraphQLError(message: 'error and data can coexist'),
+            ],
+            context: Context().withEntry(ResponseExtensions(null)),
+            response: {
+              "type": "next",
+              "data": {"foo": "bar"},
+              "errors": [
+                {"message": "error and data can coexist"}
+              ]
+            },
+          ),
+        ),
+      );
+    });
+    test('resubscribe', () async {
+      final payload = Request(
+        operation: Operation(document: gql('subscription {}')),
+      );
+      final waitForConnection = true;
+      final subscriptionDataStream =
+          socketClient.subscribe(payload, waitForConnection);
+
+      await expectLater(
+        socketClient.connectionState,
+        emitsInOrder([
+          SocketConnectionState.connecting,
+          SocketConnectionState.handshake,
+          SocketConnectionState.connected,
+        ]),
+      );
+
+      await overridePrint((_) async {
+        socketClient.onConnectionLost();
+      })();
+
+      await expectLater(
+        socketClient.connectionState,
+        emitsInOrder([
+          SocketConnectionState.notConnected,
+          SocketConnectionState.connecting,
+          SocketConnectionState.handshake,
+          SocketConnectionState.connected,
+        ]),
+      );
+
+      // ignore: unawaited_futures
+      socketClient.socketChannel!.stream
+          .where((message) => message == expectedMessage)
+          .first
+          .then((_) {
+        socketClient.socketChannel!.sink.add(jsonEncode({
+          'type': 'next',
+          'id': '01020304-0506-4708-890a-0b0c0d0e0f10',
+          'payload': {
+            'data': {'foo': 'bar'},
+            'errors': [
+              {'message': 'error and data can coexist'}
+            ]
+          }
+        }));
+      });
+
+      await expectLater(
+        subscriptionDataStream,
+        emits(
+          // todo should ids be included in response context? probably '01020304-0506-4708-890a-0b0c0d0e0f10'
+          Response(
+            data: {'foo': 'bar'},
+            errors: [
+              GraphQLError(message: 'error and data can coexist'),
+            ],
+            context: Context().withEntry(ResponseExtensions(null)),
+            response: {
+              "type": "next",
+              "data": {"foo": "bar"},
+              "errors": [
+                {"message": "error and data can coexist"}
+              ]
+            },
+          ),
+        ),
+      );
+    });
+    test('resubscribe after server disconnect', () async {
+      final payload = Request(
+        operation: Operation(document: gql('subscription {}')),
+      );
+      final waitForConnection = true;
+      final subscriptionDataStream =
+          socketClient.subscribe(payload, waitForConnection);
+
+      await expectLater(
+        socketClient.connectionState,
+        emitsInOrder([
+          SocketConnectionState.connecting,
+          SocketConnectionState.handshake,
+          SocketConnectionState.connected,
+        ]),
+      );
+
+      // We need to begin waiting on the connectionState
+      // before we issue the command to disconnect; otherwise
+      // it can reconnect so fast that it will be reconnected
+      // by the time that the expectLater check is initiated.
+      Timer(const Duration(milliseconds: 20), () async {
+        socketClient.socketChannel!.sink.add(forceDisconnectCommand);
+      });
+      // The connectionState BehaviorController emits the current state
+      // to any new listener, so we expect it to start in the connected
+      // state, transition to notConnected, and then reconnect after that.
+      await expectLater(
+        socketClient.connectionState,
+        emitsInOrder([
+          SocketConnectionState.connected,
+          SocketConnectionState.notConnected,
+          SocketConnectionState.connecting,
+          SocketConnectionState.handshake,
+          SocketConnectionState.connected,
+        ]),
+      );
+
+      // ignore: unawaited_futures
+      socketClient.socketChannel!.stream
+          .where((message) => message == expectedMessage)
+          .first
+          .then((_) {
+        socketClient.socketChannel!.sink.add(jsonEncode({
+          'type': 'next',
+          'id': '01020304-0506-4708-890a-0b0c0d0e0f10',
+          'payload': {
+            'data': {'foo': 'bar'},
+            'errors': [
+              {'message': 'error and data can coexist'}
+            ]
+          }
+        }));
+      });
+
+      await expectLater(
+        subscriptionDataStream,
+        emits(
+          // todo should ids be included in response context? probably '01020304-0506-4708-890a-0b0c0d0e0f10'
+          Response(
+            data: {'foo': 'bar'},
+            errors: [
+              GraphQLError(message: 'error and data can coexist'),
+            ],
+            context: Context().withEntry(ResponseExtensions(null)),
+            response: {
+              "type": "next",
               "data": {"foo": "bar"},
               "errors": [
                 {"message": "error and data can coexist"}


### PR DESCRIPTION
Describe the purpose of the pull request.

#### Fixes / Enhancements
The implementation of `graphql-transport-ws` fails on the first message as it's only sent if the connection controller is in the `connected` state. For this protocol, the state is instead set to `handshake` during the first `_write()`.

https://github.com/zino-hofmann/graphql-flutter/blob/02be959597f0ffe0c21a227a2d1fdb02b3f56831/packages/graphql/lib/src/links/websocket_link/websocket_client.dart#L250-L256

Without this, the connection fails with the following log:
```
flutter: Initialising connection
flutter: There was an error causing connection lost: Bad state: No element
flutter: Disconnected from websocket.
```
