### PR TITLE
Fix wrong default policy merging in `useWatchQuery/Mutation`.

### DIFF
--- a/packages/graphql_flutter/lib/src/widgets/hooks/watch_query.dart
+++ b/packages/graphql_flutter/lib/src/widgets/hooks/watch_query.dart
@@ -75,7 +75,7 @@ ObservableQuery<TParsed> useWatchQueryOnClient<TParsed>(
 ) {
   final overwrittenOptions = useMemoized(() {
     final policies =
-        client.defaultPolicies.query.withOverrides(options.policies);
+        client.defaultPolicies.watchQuery.withOverrides(options.policies);
     return options.copyWithPolicies(policies);
   }, [options]);
 
@@ -98,7 +98,7 @@ ObservableQuery<TParsed> useWatchMutationOnClient<TParsed>(
 ) {
   final overwrittenOptions = useMemoized(() {
     final policies =
-        client.defaultPolicies.mutate.withOverrides(options.policies);
+        client.defaultPolicies.watchMutation.withOverrides(options.policies);
     return options.copyWithPolicies(policies);
   }, [options]);
   return use(

--- a/packages/graphql_flutter/test/widgets/query_test.dart
+++ b/packages/graphql_flutter/test/widgets/query_test.dart
@@ -352,7 +352,7 @@ void main() {
         'does not issues new network request when policies are effectively unchanged',
         (WidgetTester tester) async {
       final page = Page(
-        fetchPolicy: client!.value.defaultPolicies.query.fetch,
+        fetchPolicy: client!.value.defaultPolicies.watchQuery.fetch,
         errorPolicy: null,
       );
 


### PR DESCRIPTION
Hi, thanks to great work.
Current `useWatchQuery` refers to `defaultPolicies.query` rather given `defaultPolicies.watchQuery`.
Also `useWatchMutation` refers to `defaultPolicies.mutate`.

If it is not intentional... please check this PR.