### PR TITLE
ci: patch release tag to filtering the packages

### DIFF
--- a/.github/workflows/packages_release.yml
+++ b/.github/workflows/packages_release.yml
@@ -4,7 +4,7 @@ on:
   release:
     types: [created]
     tags:
-      - v-*
+      - v-packages-*
 jobs:
   publishing_client:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR should make us available to make a better filter when we want to release only one package because, at this moment when we release one specific package, we run also the Ci for the package.

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>

<!--
### Breaking changes

- Broke ... because ... .

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated ... .

#### Docs

- Added ... .
- Updated ... .
-->