### PR TITLE
Fix addResult not merging fresh result bug

### DIFF
--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -250,9 +250,8 @@ class ObservableQuery<TParsed> {
   /// Called internally by the [QueryManager]
   void addResult(QueryResult<TParsed> result, {bool fromRebroadcast = false}) {
     // don't overwrite results due to some async/optimism issue
-    if (latestResult != null &&
-        latestResult!.source == QueryResultSource.network &&
-        latestResult!.timestamp.isAfter(result.timestamp)) {
+    if (latestResult?.source == QueryResultSource.network &&
+        latestResult?.timestamp.isAfter(result.timestamp) == true) {
       return;
     }
 

--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -251,6 +251,7 @@ class ObservableQuery<TParsed> {
   void addResult(QueryResult<TParsed> result, {bool fromRebroadcast = false}) {
     // don't overwrite results due to some async/optimism issue
     if (latestResult != null &&
+        latestResult!.source == QueryResultSource.network &&
         latestResult!.timestamp.isAfter(result.timestamp)) {
       return;
     }


### PR DESCRIPTION
Using `FetchPolicy.cacheFirst` sometimes makes useQuery stream's latestResult.timestamp newest.
I didn't investigate further and don't know about detailed structure of QueryManager.
But the practical problem is that while using `fetchMore`, cached result's timestamp is sometimes older than newly fetched result's timestamp in close different. (eg. less than 50ms.)
That blocks new result being merged to query result.

In my usecase.
In infinite scroll with CacheFirst query + and FetchMore strategy.
The problem happens by turns:
- at first fetchMore attempt OK
- at second attempt: merge failed (nothing updated)
- at third attempt OK
- at fourth attempt merge failed
- ..

https://github.com/zino-hofmann/graphql-flutter/blob/81028b307a4537faafce313430d68d61ff64b805/packages/graphql/lib/src/core/observable_query.dart#L253:L255
Made a change to above block to only compare `latestResult` from `QueryResultSource.network`

I made a local fix for my urgent project. And sorry for the lack of detail reproduction.
But i hope you (who knows this project in deep level) can find out some potential problem from above description.
Later if i had a time to reproduce it with simple code, i will attach that.
For now, it would be please to take it as a simple bug report.
