### PR TITLE
Update exceptions with stacktraces

### DIFF
--- a/packages/graphql/lib/src/cache/_normalizing_data_proxy.dart
+++ b/packages/graphql/lib/src/cache/_normalizing_data_proxy.dart
@@ -144,10 +144,11 @@ abstract class NormalizingDataProxy extends GraphQLDataProxy {
       if (broadcast ?? true) {
         broadcastRequested = true;
       }
-    } on PartialDataException catch (e) {
+    } on PartialDataException catch (e, stackTrace) {
       if (request.validatesStructureOf(data)) {
         throw CacheMisconfigurationException(
           e,
+          stackTrace,
           request: request,
           data: data,
         );
@@ -182,10 +183,11 @@ abstract class NormalizingDataProxy extends GraphQLDataProxy {
       if (broadcast ?? true) {
         broadcastRequested = true;
       }
-    } on PartialDataException catch (e) {
+    } on PartialDataException catch (e, stackTrace) {
       if (request.validatesStructureOf(data)) {
         throw CacheMisconfigurationException(
           e,
+          stackTrace,
           fragmentRequest: request,
           data: data,
         );

--- a/packages/graphql/lib/src/core/_query_write_handling.dart
+++ b/packages/graphql/lib/src/core/_query_write_handling.dart
@@ -6,7 +6,7 @@ typedef _IntWriteQuery = void Function(
 
 /// Internal [PartialDataException] handling callback
 typedef _IntPartialDataHandler = MismatchedDataStructureException Function(
-    PartialDataException failure);
+    PartialDataException failure, StackTrace stackTrace);
 
 extension InternalQueryWriteHandling on QueryManager {
   /// Merges exceptions into `queryResult` and
@@ -29,10 +29,10 @@ extension InternalQueryWriteHandling on QueryManager {
         exception: queryResult.exception,
         linkException: failure,
       );
-    } on PartialDataException catch (failure) {
+    } on PartialDataException catch (failure, stackTrace) {
       queryResult!.exception = coalesceErrors(
         exception: queryResult.exception,
-        linkException: onPartial(failure),
+        linkException: onPartial(failure, stackTrace),
       );
     }
     return false;
@@ -61,8 +61,10 @@ extension InternalQueryWriteHandling on QueryManager {
                 response.data,
                 queryResult,
                 writeQuery: (req, data) => cache.writeQuery(req, data: data!),
-                onPartial: (failure) => UnexpectedResponseStructureException(
+                onPartial: (failure, stackTrace) =>
+                    UnexpectedResponseStructureException(
                   failure,
+                  stackTrace,
                   request: request,
                   parsedResponse: response,
                 ),
@@ -84,8 +86,9 @@ extension InternalQueryWriteHandling on QueryManager {
         data,
         queryResult,
         writeQuery: writeQuery,
-        onPartial: (failure) => MismatchedDataStructureException(
+        onPartial: (failure, stackTrace) => MismatchedDataStructureException(
           failure,
+          stackTrace,
           request: request,
           data: data,
         ),

--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -519,7 +519,7 @@ class QueryManager {
 
 QueryResult<TParsed> _wrapFailure<TParsed>(
   BaseOptions<TParsed> options,
-  dynamic ex,
+  Object ex,
   StackTrace trace,
 ) =>
     QueryResult(

--- a/packages/graphql/lib/src/exceptions/exceptions.dart
+++ b/packages/graphql/lib/src/exceptions/exceptions.dart
@@ -11,9 +11,10 @@ import 'package:graphql/src/exceptions/network.dart'
 export 'package:graphql/src/exceptions/network.dart'
     if (dart.library.io) 'package:graphql/src/exceptions/network_io.dart';
 
-LinkException translateFailure(dynamic failure, StackTrace trace) {
+LinkException translateFailure(Object failure, StackTrace trace) {
   if (failure is LinkException) {
     return failure;
   }
-  return network.translateFailure(failure) ?? UnknownException(failure, trace);
+  return network.translateFailure(failure, trace) ??
+      UnknownException(failure, trace);
 }

--- a/packages/graphql/lib/src/exceptions/exceptions_next.dart
+++ b/packages/graphql/lib/src/exceptions/exceptions_next.dart
@@ -14,7 +14,7 @@ export 'package:normalize/normalize.dart' show PartialDataException;
 @immutable
 class CacheMissException extends LinkException {
   CacheMissException(this.message, this.request, {this.expectedData})
-      : super(null);
+      : super(null, null);
 
   final String message;
   final Request request;
@@ -37,18 +37,25 @@ class CacheMissException extends LinkException {
 /// [CacheMisconfigurationException].
 class MismatchedDataStructureException extends LinkException {
   const MismatchedDataStructureException(
-    this.originalException, {
+    this.originalException,
+    this.originalStackTrace, {
     this.request,
     required this.data,
-  }) : super(originalException);
+  }) : super(originalException, originalStackTrace);
 
   final Map<String, dynamic>? data;
   final Request? request;
+
+  @override
   final PartialDataException originalException;
+
+  @override
+  final StackTrace originalStackTrace;
 
   @override
   String toString() => 'MismatchedDataStructureException('
       '$originalException, '
+      '$originalStackTrace, '
       'request: ${request}, '
       'data: ${data}, '
       ')';
@@ -62,11 +69,12 @@ class MismatchedDataStructureException extends LinkException {
 class CacheMisconfigurationException extends LinkException
     implements MismatchedDataStructureException {
   const CacheMisconfigurationException(
-    this.originalException, {
+    this.originalException,
+    this.originalStackTrace, {
     this.request,
     this.fragmentRequest,
     required this.data,
-  }) : super(originalException);
+  }) : super(originalException, originalStackTrace);
 
   final Request? request;
   final FragmentRequest? fragmentRequest;
@@ -76,9 +84,13 @@ class CacheMisconfigurationException extends LinkException
   final PartialDataException originalException;
 
   @override
+  final StackTrace originalStackTrace;
+
+  @override
   String toString() => [
         'CacheMisconfigurationException(',
         '$originalException, ',
+        '$originalStackTrace, ',
         if (request != null) 'request: ${request}',
         if (fragmentRequest != null) 'fragmentRequest : ${fragmentRequest}',
         'data: ${data}, ',
@@ -94,12 +106,15 @@ class CacheMisconfigurationException extends LinkException
 class UnexpectedResponseStructureException extends ServerException
     implements MismatchedDataStructureException {
   const UnexpectedResponseStructureException(
-    this.originalException, {
+    this.originalException,
+    this.originalStackTrace, {
     required this.request,
     required Response parsedResponse,
   }) : super(
-            parsedResponse: parsedResponse,
-            originalException: originalException);
+          parsedResponse: parsedResponse,
+          originalException: originalException,
+          originalStackTrace: originalStackTrace,
+        );
 
   @override
   final Request request;
@@ -111,8 +126,12 @@ class UnexpectedResponseStructureException extends ServerException
   final PartialDataException originalException;
 
   @override
+  final StackTrace originalStackTrace;
+
+  @override
   String toString() => 'UnexpectedResponseStructureException('
       '$originalException, '
+      '$originalStackTrace, '
       'request: ${request}, '
       'parsedResponse: ${parsedResponse}, '
       ')';
@@ -124,13 +143,10 @@ class UnexpectedResponseStructureException extends ServerException
 class UnknownException extends LinkException {
   String get message => 'Unhandled Client-Side Exception: $originalException';
 
-  /// stacktrace of the [originalException].
-  final StackTrace originalStackTrace;
-
   const UnknownException(
-    dynamic originalException,
-    this.originalStackTrace,
-  ) : super(originalException);
+    Object originalException,
+    StackTrace originalStackTrace,
+  ) : super(originalException, originalStackTrace);
 
   @override
   String toString() =>
@@ -147,8 +163,11 @@ class OperationException implements Exception {
   /// Errors encountered during execution such as network or cache errors
   LinkException? linkException;
 
+  StackTrace? originalStackTrace;
+
   OperationException({
     this.linkException,
+    this.originalStackTrace,
     Iterable<GraphQLError> graphqlErrors = const [],
   }) : this.graphqlErrors = graphqlErrors.toList();
 

--- a/packages/graphql/lib/src/exceptions/network.dart
+++ b/packages/graphql/lib/src/exceptions/network.dart
@@ -2,11 +2,21 @@ import 'package:http/http.dart' as http show ClientException;
 
 import 'package:gql_link/gql_link.dart' show LinkException;
 
-/// Exception occurring when there is a network-level error
+/// Exception occurring when there is a network-level error.
+/// This constructor is deprecated, use
+/// [NetworkException.fromException] instead.
 class NetworkException extends LinkException {
+  @deprecated
   NetworkException({
     required Object originalException,
     StackTrace originalStackTrace = StackTrace.empty,
+    this.message,
+    required this.uri,
+  }) : super(originalException, originalStackTrace);
+
+  NetworkException.fromException({
+    required Object originalException,
+    required StackTrace originalStackTrace,
     this.message,
     required this.uri,
   }) : super(originalException, originalStackTrace);
@@ -25,7 +35,7 @@ class NetworkException extends LinkException {
 /// will be all that is necessary
 NetworkException? translateFailure(Object failure, StackTrace stackTrace) {
   if (failure is http.ClientException) {
-    return NetworkException(
+    return NetworkException.fromException(
       originalException: failure,
       originalStackTrace: stackTrace,
       message: failure.message,

--- a/packages/graphql/lib/src/exceptions/network.dart
+++ b/packages/graphql/lib/src/exceptions/network.dart
@@ -5,10 +5,11 @@ import 'package:gql_link/gql_link.dart' show LinkException;
 /// Exception occurring when there is a network-level error
 class NetworkException extends LinkException {
   NetworkException({
-    dynamic originalException,
+    required Object originalException,
+    StackTrace originalStackTrace = StackTrace.empty,
     this.message,
     required this.uri,
-  }) : super(originalException);
+  }) : super(originalException, originalStackTrace);
 
   final String? message;
   final Uri? uri;
@@ -22,10 +23,11 @@ class NetworkException extends LinkException {
 /// Once `gql_link` has robust http and socket exception handling,
 /// this and `./network.dart` can be removed and `./exceptions_next.dart`
 /// will be all that is necessary
-NetworkException? translateFailure(dynamic failure) {
+NetworkException? translateFailure(Object failure, StackTrace stackTrace) {
   if (failure is http.ClientException) {
     return NetworkException(
       originalException: failure,
+      originalStackTrace: stackTrace,
       message: failure.message,
       uri: failure.uri,
     );

--- a/packages/graphql/lib/src/exceptions/network_io.dart
+++ b/packages/graphql/lib/src/exceptions/network_io.dart
@@ -8,10 +8,11 @@ export './network.dart' show NetworkException;
 /// Once `gql_link` has robust http and socket exception handling,
 /// this and `./unhandled.dart` can be removed and `./exceptions_next.dart`
 /// will be all that is necessary
-base.NetworkException? translateFailure(dynamic failure) {
+base.NetworkException? translateFailure(Object failure, StackTrace stackTrace) {
   if (failure is io.SocketException) {
     return base.NetworkException(
       originalException: failure,
+      originalStackTrace: stackTrace,
       message: failure.message,
       uri: Uri(
         scheme: 'http',
@@ -20,5 +21,5 @@ base.NetworkException? translateFailure(dynamic failure) {
       ),
     );
   }
-  return base.translateFailure(failure);
+  return base.translateFailure(failure, stackTrace);
 }

--- a/packages/graphql/lib/src/exceptions/network_io.dart
+++ b/packages/graphql/lib/src/exceptions/network_io.dart
@@ -10,7 +10,7 @@ export './network.dart' show NetworkException;
 /// will be all that is necessary
 base.NetworkException? translateFailure(Object failure, StackTrace stackTrace) {
   if (failure is io.SocketException) {
-    return base.NetworkException(
+    return base.NetworkException.fromException(
       originalException: failure,
       originalStackTrace: stackTrace,
       message: failure.message,

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -6,15 +6,15 @@ homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graph
 dependencies:
   meta: ^1.3.0
   path: ^1.8.0
-  gql: ^0.13.0
-  gql_exec: ^0.4.0
-  gql_link: ^0.4.2
-  gql_http_link: ^0.4.2
-  gql_transform_link: ^0.2.0
-  gql_error_link: ^0.2.0
-  gql_dedupe_link: ^2.0.0
+  gql: ^0.14.0
+  gql_exec: ^0.4.1
+  gql_link: ^0.5.0
+  gql_http_link: ^0.4.4+1 
+  gql_transform_link: ^0.2.2
+  gql_error_link: ^0.2.3
+  gql_dedupe_link: ^2.0.3
   hive: ^2.1.0
-  normalize: ^0.6.0
+  normalize: ^0.7.1
   http: ^0.13.0
   collection: ^1.15.0
   web_socket_channel: ^2.0.0


### PR DESCRIPTION
The `qgl` suite includes now stacktraces in `LinkException` (see this PR https://github.com/gql-dart/gql/pull/331). Since that's a breaking change, I've updated it here.

I'll update this PR once the changes from `gql` make it to a stable version, but until then, I guess, it doesn't make much sense to merge this.

### Breaking changes

This might be considered a breaking change, but I guess most users aren't using `LinkExceptions` themselves.

#### Fixes / Enhancements

- Fixed usages of `LinkException`

Fixes https://github.com/zino-hofmann/graphql-flutter/issues/1220