### PR TITLE
fix(graphql): Normalization signature

### DIFF
--- a/packages/graphql/lib/src/cache/_normalizing_data_proxy.dart
+++ b/packages/graphql/lib/src/cache/_normalizing_data_proxy.dart
@@ -65,7 +65,7 @@ abstract class NormalizingDataProxy extends GraphQLDataProxy {
   /// The key differentiating factor for an implementing `cache` or `proxy`
   /// is usually how they handle [optimistic] reads.
   @protected
-  Map<String, dynamic>? readNormalized(String rootId, {bool? optimistic});
+  Map<String, dynamic>? readNormalized(String rootId, {bool optimistic});
 
   /// Write normalized data into the cache.
   ///
@@ -80,7 +80,7 @@ abstract class NormalizingDataProxy extends GraphQLDataProxy {
 
   Map<String, dynamic>? readQuery(
     Request request, {
-    bool? optimistic = true,
+    bool optimistic = true,
   }) =>
       denormalizeOperation(
         // provided from cache
@@ -100,7 +100,7 @@ abstract class NormalizingDataProxy extends GraphQLDataProxy {
 
   Map<String, dynamic>? readFragment(
     FragmentRequest fragmentRequest, {
-    bool? optimistic = true,
+    bool optimistic = true,
   }) =>
       denormalizeFragment(
         // provided from cache

--- a/packages/graphql/lib/src/cache/_optimistic_transactions.dart
+++ b/packages/graphql/lib/src/cache/_optimistic_transactions.dart
@@ -59,8 +59,8 @@ class OptimisticProxy extends NormalizingDataProxy {
 
   @override
   Map<String, dynamic>? readNormalized(String rootId,
-      {bool? optimistic = true}) {
-    if (!optimistic!) {
+      {bool optimistic = true}) {
+    if (!optimistic) {
       return cache.readNormalized(rootId, optimistic: false);
     }
     // the cache calls `patch.data.containsKey(rootId)`,

--- a/packages/graphql/lib/src/cache/data_proxy.dart
+++ b/packages/graphql/lib/src/cache/data_proxy.dart
@@ -98,7 +98,7 @@ import './fragment.dart';
 /// ```
 abstract class GraphQLDataProxy {
   /// Reads a GraphQL query from the root query id.
-  Map<String, dynamic>? readQuery(Request request, {bool? optimistic});
+  Map<String, dynamic>? readQuery(Request request, {bool optimistic});
 
   /// Reads a GraphQL fragment from any arbitrary id.
   ///
@@ -107,7 +107,7 @@ abstract class GraphQLDataProxy {
   /// to select the correct fragment.
   Map<String, dynamic>? readFragment(
     FragmentRequest fragmentRequest, {
-    bool? optimistic,
+    bool optimistic,
   });
 
   /// Writes a GraphQL query to the root query id,


### PR DESCRIPTION
There's no reason why we support `null`, `true`, and `false` here, especially when we're asserting that the argument isn't `null` immediately after.