### PR TITLE
feat(graphql_common): add common package that contains utils functions 

### DIFF
--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:graphql/src/utilities/response.dart';
+import 'package:graphql_common/graphql_common.dart';
 import 'package:meta/meta.dart';
 import 'package:collection/collection.dart';
 
@@ -26,6 +27,7 @@ class QueryManager {
   QueryManager({
     required this.link,
     required this.cache,
+    this.tracer,
     this.alwaysRebroadcast = false,
   }) {
     scheduler = QueryScheduler(
@@ -49,6 +51,10 @@ class QueryManager {
 
   /// prevents rebroadcasting for some intensive bulk operation like [refetchSafeQueries]
   bool rebroadcastLocked = false;
+
+  /// Custom Tracer specified by the user to trace the library
+  /// if the user need it.
+  final Tracer? tracer;
 
   ObservableQuery<TParsed> watchQuery<TParsed>(
       WatchQueryOptions<TParsed> options) {

--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -1,10 +1,9 @@
 import 'package:meta/meta.dart';
 import 'dart:async';
-
 import 'package:graphql/src/core/core.dart';
 import 'package:graphql/src/cache/cache.dart';
-
 import 'package:graphql/src/core/fetch_more.dart';
+import 'package:graphql_common/graphql_common.dart';
 
 /// Universal GraphQL Client with configurable caching and [link][] system.
 /// modelled after the [`apollo-client`][ac].
@@ -24,12 +23,14 @@ class GraphQLClient implements GraphQLDataProxy {
   GraphQLClient({
     required this.link,
     required this.cache,
+    this.tracer,
     DefaultPolicies? defaultPolicies,
     bool alwaysRebroadcast = false,
   })  : defaultPolicies = defaultPolicies ?? DefaultPolicies(),
         queryManager = QueryManager(
           link: link,
           cache: cache,
+          tracer: tracer,
           alwaysRebroadcast: alwaysRebroadcast,
         );
 
@@ -44,11 +45,16 @@ class GraphQLClient implements GraphQLDataProxy {
 
   late final QueryManager queryManager;
 
+  /// Custom Tracer specified by the user to trace the library
+  /// if the user need it.
+  final Tracer? tracer;
+
   /// Create a copy of the client with the provided information.
   GraphQLClient copyWith(
       {Link? link,
       GraphQLCache? cache,
       DefaultPolicies? defaultPolicies,
+      Tracer? tracer,
       bool? alwaysRebroadcast}) {
     return GraphQLClient(
         link: link ?? this.link,

--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -7,6 +7,7 @@ import 'package:gql_exec/gql_exec.dart';
 import 'package:graphql/src/core/query_options.dart' show WithType;
 import 'package:graphql/src/links/gql_links.dart';
 import 'package:graphql/src/utilities/platform.dart';
+import 'package:graphql_common/graphql_common.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:stream_channel/stream_channel.dart';
@@ -48,7 +49,12 @@ class SocketClientConfig {
     this.initialPayload,
     this.headers,
     this.connectFn,
+    this.tracer,
   });
+
+  /// Custom Tracer specified by the user to trace the library
+  /// if the user need it.
+  final Tracer? tracer;
 
   /// Serializer used to serialize request
   final RequestSerializer serializer;

--- a/packages/graphql/lib/src/links/websocket_link/websocket_link.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_link.dart
@@ -1,5 +1,6 @@
 import 'package:gql_exec/gql_exec.dart';
 import 'package:gql_link/gql_link.dart';
+import 'package:graphql_common/graphql_common.dart';
 
 import './websocket_client.dart';
 
@@ -17,6 +18,7 @@ class WebSocketLink extends Link {
     this.url, {
     this.config = const SocketClientConfig(),
     this.subProtocol = GraphQLProtocol.graphqlWs,
+    this.tracer,
   });
 
   final String url;
@@ -25,6 +27,10 @@ class WebSocketLink extends Link {
 
   // cannot be final because we're changing the instance upon a header change.
   SocketClient? _socketClient;
+
+  /// Custom Tracer specified by the user to trace the library
+  /// if the user need it.
+  final Tracer? tracer;
 
   @override
   Stream<Response> request(Request request, [forward]) async* {

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -21,6 +21,8 @@ dependencies:
   stream_channel: ^2.1.0
   rxdart: ^0.27.1
   uuid: ^3.0.1
+  graphql_common:
+    path: ../graphql_common
 
 dev_dependencies:
   async: ^2.5.0

--- a/packages/graphql_common/.gitignore
+++ b/packages/graphql_common/.gitignore
@@ -1,0 +1,10 @@
+# Files and directories created by pub.
+.dart_tool/
+.packages
+
+# Conventional directory for build outputs.
+build/
+
+# Omit committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/packages/graphql_common/CHANGELOG.md
+++ b/packages/graphql_common/CHANGELOG.md
@@ -1,0 +1,3 @@
+## 1.0.0
+
+- Initial version.

--- a/packages/graphql_common/README.md
+++ b/packages/graphql_common/README.md
@@ -1,0 +1,39 @@
+<!-- 
+This README describes the package. If you publish this package to pub.dev,
+this README's contents appear on the landing page for your package.
+
+For information about how to write a good package README, see the guide for
+[writing package pages](https://dart.dev/guides/libraries/writing-package-pages). 
+
+For general information about developing packages, see the Dart guide for
+[creating packages](https://dart.dev/guides/libraries/create-library-packages)
+and the Flutter guide for
+[developing packages and plugins](https://flutter.dev/developing-packages). 
+-->
+
+TODO: Put a short description of the package here that helps potential users
+know whether this package might be useful for them.
+
+## Features
+
+TODO: List what your package can do. Maybe include images, gifs, or videos.
+
+## Getting started
+
+TODO: List prerequisites and provide or point to information on how to
+start using the package.
+
+## Usage
+
+TODO: Include short and useful examples for package users. Add longer examples
+to `/example` folder. 
+
+```dart
+const like = 'sample';
+```
+
+## Additional information
+
+TODO: Tell users more about the package: where to find more information, how to 
+contribute to the package, how to file issues, what response they can expect 
+from the package authors, and more.

--- a/packages/graphql_common/analysis_options.yaml
+++ b/packages/graphql_common/analysis_options.yaml
@@ -1,0 +1,30 @@
+# This file configures the static analysis results for your project (errors,
+# warnings, and lints).
+#
+# This enables the 'recommended' set of lints from `package:lints`.
+# This set helps identify many issues that may lead to problems when running
+# or consuming Dart code, and enforces writing Dart using a single, idiomatic
+# style and format.
+#
+# If you want a smaller set of lints you can change this to specify
+# 'package:lints/core.yaml'. These are just the most critical lints
+# (the recommended set includes the core lints).
+# The core lints are also what is used by pub.dev for scoring packages.
+
+include: package:lints/recommended.yaml
+
+# Uncomment the following section to specify additional rules.
+
+# linter:
+#   rules:
+#     - camel_case_types
+
+# analyzer:
+#   exclude:
+#     - path/to/excluded/files/**
+
+# For more information about the core and recommended set of lints, see
+# https://dart.dev/go/core-lints
+
+# For additional information about configuring this file, see
+# https://dart.dev/guides/language/analysis-options

--- a/packages/graphql_common/example/graphql_common_example.dart
+++ b/packages/graphql_common/example/graphql_common_example.dart
@@ -1,0 +1,1 @@
+void main() {}

--- a/packages/graphql_common/lib/graphql_common.dart
+++ b/packages/graphql_common/lib/graphql_common.dart
@@ -1,0 +1,7 @@
+/// Support for doing something awesome.
+///
+/// More dartdocs go here.
+library graphql_common;
+
+export 'src/tracing/tracer.dart';
+export 'src/tracing/logger_tracer.dart';

--- a/packages/graphql_common/lib/src/tracing/logger_tracer.dart
+++ b/packages/graphql_common/lib/src/tracing/logger_tracer.dart
@@ -1,0 +1,20 @@
+import 'package:graphql_common/src/tracing/tracer.dart';
+import 'package:logger/logger.dart';
+
+class LoggerTracer extends Tracer {
+  late Logger _logger;
+
+  LoggerTracer(
+      {LogFilter? filter,
+      LogPrinter? printer,
+      LogOutput? output,
+      Level? level}) {
+    _logger =
+        Logger(filter: filter, printer: printer, output: output, level: level);
+  }
+
+  @override
+  Future<void> asyncTrace(String msg, {Map<String, dynamic>? opts}) {
+    return Future(() => _logger.d(msg));
+  }
+}

--- a/packages/graphql_common/lib/src/tracing/tracer.dart
+++ b/packages/graphql_common/lib/src/tracing/tracer.dart
@@ -1,0 +1,10 @@
+/// Tracer is an abstract class that provide the basic blocs to
+/// build an application tracer (aka Logger).
+///
+/// author: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>
+abstract class Tracer {
+  /// Async function to start to tracing the library at runtime
+  /// useful when the user want log the information in an external
+  /// source, and it is required an async trace!
+  Future<void> asyncTrace(String msg, {Map<String, dynamic>? opts});
+}

--- a/packages/graphql_common/pubspec.yaml
+++ b/packages/graphql_common/pubspec.yaml
@@ -1,0 +1,17 @@
+name: graphql_common
+description: A starting point for Dart libraries or applications.
+version: 0.0.1
+# homepage: https://www.example.com
+
+environment:
+  sdk: '>=2.12.6 <3.0.0'
+
+dependencies:
+  logger: ^1.1.0
+
+
+dev_dependencies:
+  lints: ^2.0.0
+  test: ^1.16.0
+  graphql:
+    path: ../graphql

--- a/packages/graphql_common/test/graphql_common_test.dart
+++ b/packages/graphql_common/test/graphql_common_test.dart
@@ -1,0 +1,11 @@
+import 'package:test/test.dart';
+
+void main() {
+  group('A group of tests', () {
+    setUp(() {
+      // Additional setup goes here.
+    });
+
+    test('First Test', () {});
+  });
+}

--- a/packages/graphql_flutter/example/lib/generated_plugin_registrant.dart
+++ b/packages/graphql_flutter/example/lib/generated_plugin_registrant.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: directives_ordering
 // ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: depend_on_referenced_packages
 
 import 'package:connectivity_plus_web/connectivity_plus_web.dart';
 


### PR DESCRIPTION
We have a big lack in the library, we can not trace in case of a fancy problem, with this PR I'm proposing to put a generic interface + a Logger trace inside a separate package, and use it inside the client.

This will help us to safely make refactoring and trace the example that I proposed in other open PRs today!