### PR TITLE
Null access fix

### DIFF
--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -493,7 +493,8 @@ class QueryManager {
     ObservableQuery<Object?> query,
     Map<String, dynamic>? cachedData,
   ) =>
-      cachedData != null && query.latestResult != null &&
+      cachedData != null &&
+      query.latestResult != null &&
       (alwaysRebroadcast || !_deepEquals(query.latestResult!.data, cachedData));
 
   void setQuery(ObservableQuery<Object?> observableQuery) {

--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -493,7 +493,7 @@ class QueryManager {
     ObservableQuery<Object?> query,
     Map<String, dynamic>? cachedData,
   ) =>
-      cachedData != null &&
+      cachedData != null && query.latestResult != null &&
       (alwaysRebroadcast || !_deepEquals(query.latestResult!.data, cachedData));
 
   void setQuery(ObservableQuery<Object?> observableQuery) {


### PR DESCRIPTION
This PR fixes a null access error in query manager. If query.latestResult is null, _cachedDataHasChangedFor will cause an error. This is easily fixes by checking that query.latestResult is not null.