### PR TITLE
Fix links in pubspec.yaml

### DIFF
--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -1,7 +1,8 @@
 name: graphql
 description: A stand-alone GraphQL client for Dart, bringing all the features from a modern GraphQL client to one easy to use package.
 version: 5.1.2-beta.4
-homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql
+repository: https://github.com/zino-app/graphql-flutter/tree/main/packages/graphql
+issue_tracker: https://github.com/zino-hofmann/graphql-flutter/issues
 
 dependencies:
   meta: ^1.3.0

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -1,7 +1,8 @@
 name: graphql_flutter
 description: A GraphQL client for Flutter, bringing all the features from a modern GraphQL client to one easy to use package.
 version: 5.1.1-beta.4
-homepage: https://github.com/zino-app/graphql-flutter/tree/master/packages/graphql_flutter
+repository: https://github.com/zino-app/graphql-flutter/tree/main/packages/graphql_flutter
+issue_tracker: https://github.com/zino-hofmann/graphql-flutter/issues
 
 dependencies:
   graphql: ^5.1.2-beta.1


### PR DESCRIPTION
This fixes links in the pubspec.yaml files of this project.
As you can see in the diff, the current links still point to the master branch, which isn't used anymore. In addition, I've also added the issue tracker link.

#### Docs

- Updated links in pubspec.yaml files