### PR TITLE
Allow list of errors as payloads for graphql-transport-ws subprotocol's "error" message type

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_messages.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_messages.dart
@@ -57,8 +57,7 @@ abstract class GraphQLSocketMessage extends JsonSerializable {
     final Map<String, dynamic> map =
         json.decode(message as String) as Map<String, dynamic>;
     final String type = (map['type'] ?? 'unknown') as String;
-    final payload =
-        (map['payload'] ?? <String, dynamic>{}) as Map<String, dynamic>;
+    final payload = map['payload'] ?? <String, dynamic>{};
     final String id = (map['id'] ?? 'none') as String;
 
     switch (type) {
@@ -77,15 +76,15 @@ abstract class GraphQLSocketMessage extends JsonSerializable {
 
       // for completeness
       case MessageTypes.subscribe:
-        return SubscribeOperation(id, payload);
+        return SubscribeOperation(id, payload as Map<String, dynamic>);
       case MessageTypes.start:
-        return StartOperation(id, payload);
+        return StartOperation(id, payload as Map<String, dynamic>);
       case MessageTypes.stop:
         return StopOperation(id);
       case MessageTypes.ping:
-        return PingMessage(payload);
+        return PingMessage(payload as Map<String, dynamic>);
       case MessageTypes.pong:
-        return PongMessage(payload);
+        return PongMessage(payload as Map<String, dynamic>);
 
       case MessageTypes.data:
         return SubscriptionData(id, payload['data'], payload['errors']);

--- a/packages/graphql/test/websocket_test.dart
+++ b/packages/graphql/test/websocket_test.dart
@@ -70,6 +70,47 @@ Future<void> main() async {
     });
   });
 
+  group('GraphQLSocketMessage.parse', () {
+    test('graphql-transport-ws subprotocol with errors', () {
+      const payload = [
+        {
+          'message': 'Cannot query field "wrongQuery" on type "Query".',
+          'locations': [
+            {'line': 1, 'column': 2}
+          ],
+          'extensions': {
+            'validationError': {
+              'spec': 'https://spec.graphql.org/draft/#sec-Field-Selections',
+            }
+          }
+        }
+      ];
+
+      const message = {'id': 'message-id', 'type': 'error', 'payload': payload};
+      final parsed = GraphQLSocketMessage.parse(jsonEncode(message));
+      expect(parsed, isA<SubscriptionError>());
+      expect(parsed.toJson(), message);
+    });
+
+    test('graphql-ws apollo subprotocol with errors', () {
+      const payload = {
+        'message': 'Cannot query field "wrongQuery" on type "Query".',
+        'locations': [
+          {'line': 1, 'column': 2}
+        ],
+        'extensions': {
+          'validationError': {
+            'spec': 'https://spec.graphql.org/draft/#sec-Field-Selections',
+          }
+        }
+      };
+      const message = {'id': 'message-id', 'type': 'error', 'payload': payload};
+      final parsed = GraphQLSocketMessage.parse(jsonEncode(message));
+      expect(parsed, isA<SubscriptionError>());
+      expect(parsed.toJson(), message);
+    });
+  });
+
   group('SocketClient without payload', () {
     late SocketClient socketClient;
     StreamController<dynamic> controller;


### PR DESCRIPTION
Fixes https://github.com/zino-hofmann/graphql-flutter/issues/1241.

This allows the payload property in the response to be a `List` in the `GraphQLSocketMessage.parse` function. Specifically for the `SubscriptionError` class since the payload should be a List of errors for messages of type `error` following the [`graphql-transport-ws` subprotocol specification](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#error).

It was tested with a [leto](https://github.com/juancastillo0/leto) server [here](https://github.com/juancastillo0/cidart/blob/a6f67b7f06982a40167645ddc2d4f09d82173612/leto_server/test/client_test.dart#L89).

Thanks!