### PR TITLE
ci: remove the spec dependences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,13 @@
 CC=dart pub global run melos
-CC_TEST=spec
+#CC_TEST=spec
+CC_TEST=for d in ./packages/*/ ; do (echo $$d && cd $$d && dart test); done
 CC_CHANGELOG=dart pub global run changelog_cmd
 
 default: analyze check
 
 dep:
 	dart pub global activate melos;
-	dart pub global activate spec_cli;
+	#dart pub global activate spec_cli;
 	dart pub global activate changelog_cmd;
 	$(CC) bootstrap
 

--- a/packages/graphql_flutter/example/lib/generated_plugin_registrant.dart
+++ b/packages/graphql_flutter/example/lib/generated_plugin_registrant.dart
@@ -4,6 +4,7 @@
 
 // ignore_for_file: directives_ordering
 // ignore_for_file: lines_longer_than_80_chars
+// ignore_for_file: depend_on_referenced_packages
 
 import 'package:connectivity_plus_web/connectivity_plus_web.dart';
 


### PR DESCRIPTION
Recently one of the test ran `spec` is break for some reason and one of the solution stolen around is remove it 

Credit https://github.com/dart-lightning/lndart.cln/pull/106

This Pr fix the following build error in the CI

```
Failed to build spec_cli:main:
/opt/hostedtoolcache/flutter/3.3.3-stable/x64/.pub-cache/hosted/pub.dartlang.org/spec_cli-0.1.2+2/lib/src/command_runner.dart:148:31: Error: The argument type 'AlwaysAliveRefreshable<StateController<RegExp?>>' can't be assigned to the parameter type 'ProviderBase<dynamic>'.
 - 'AlwaysAliveRefreshable' is from 'package:riverpod/src/framework.dart' ('/opt/hostedtoolcache/flutter/3.3.3-stable/x64/.pub-cache/hosted/pub.dartlang.org/riverpod-2.0.2/lib/src/framework.dart').
 - 'StateController' is from 'package:riverpod/src/state_controller.dart' ('/opt/hostedtoolcache/flutter/3.3.3-stable/x64/.pub-cache/hosted/pub.dartlang.org/riverpod-2.0.2/lib/src/state_controller.dart').
 - 'RegExp' is from 'dart:core'.
 - 'ProviderBase' is from 'package:riverpod/src/framework.dart' ('/opt/hostedtoolcache/flutter/3.3.3-stable/x64/.pub-cache/hosted/pub.dartlang.org/riverpod-2.0.2/lib/src/framework.dart').
    ref.read($testNameFilters.notifier).state = options.testNameFilters.isEmpty
```