### PR TITLE
feat(graphql): add raw to exceptions on QueryResult

### DIFF
--- a/packages/graphql/lib/src/exceptions/exceptions_next.dart
+++ b/packages/graphql/lib/src/exceptions/exceptions_next.dart
@@ -165,9 +165,12 @@ class OperationException implements Exception {
 
   StackTrace? originalStackTrace;
 
+  List<dynamic>? raw;
+
   OperationException({
     this.linkException,
     this.originalStackTrace,
+    this.raw,
     Iterable<GraphQLError> graphqlErrors = const [],
   }) : this.graphqlErrors = graphqlErrors.toList();
 
@@ -188,6 +191,7 @@ class OperationException implements Exception {
 OperationException? coalesceErrors({
   List<GraphQLError>? graphqlErrors,
   LinkException? linkException,
+  List<dynamic>? raw,
   OperationException? exception,
 }) {
   if (exception != null ||
@@ -195,6 +199,7 @@ OperationException? coalesceErrors({
       (graphqlErrors != null && graphqlErrors.isNotEmpty)) {
     return OperationException(
       linkException: linkException ?? exception?.linkException,
+      raw: raw,
       graphqlErrors: [
         if (graphqlErrors != null) ...graphqlErrors,
         if (exception?.graphqlErrors != null) ...exception!.graphqlErrors

--- a/packages/graphql/lib/src/utilities/response.dart
+++ b/packages/graphql/lib/src/utilities/response.dart
@@ -9,6 +9,7 @@ QueryResult<TParsed> mapFetchResultToQueryResult<TParsed>(
 }) {
   List<GraphQLError>? errors;
   Map<String, dynamic>? data;
+  Map<String, dynamic>? raw;
 
   // check if there are errors and apply the error policy if so
   // in a nutshell: `ignore` swallows errors, `none` swallows data
@@ -34,11 +35,16 @@ QueryResult<TParsed> mapFetchResultToQueryResult<TParsed>(
     data = response.data;
   }
 
+  raw = response.response;
+
   return QueryResult(
     options: options,
     data: data,
     context: response.context,
     source: source,
-    exception: coalesceErrors(graphqlErrors: errors),
+    exception: coalesceErrors(
+      graphqlErrors: errors,
+      raw: raw['errors'] as List<dynamic>?,
+    ),
   );
 }


### PR DESCRIPTION
A while ago, a coworker opened an [issue](https://github.com/zino-hofmann/graphql-flutter/issues/903) reporting a need in our project about having access to the raw error to access some specific properties of it, such as the code for example. Recently, this issue was closed, but our need persists. With that, I decided to try to contribute to the package and add the parameter myself. First I researched the packages used and realized that the answer is obtained from the gql_exec package. In version 0.4.1 of this package there was a change in the Response class meeting an [issue](https://github.com/gql-dart/gql/pull/249) with similar needs to ours. This change makes the Response class now have an attribute also called response where the raw http of the response is.
Using this new attribute, I propose a change in the assembly of the QueryResult class. The most viable solution I found is to include the list of errors received in the raw together in an attribute of the OperationException class that is added to the QueryResult in case of an error. For the needs of our project, it was a good solution, I hope it is approved and can contribute to the needs of other projects as well.