### PR TITLE
fix(graphql): fixing the dart analyzer error

### DIFF
--- a/packages/graphql/test/graphql_client_test.dart
+++ b/packages/graphql/test/graphql_client_test.dart
@@ -150,7 +150,7 @@ void main() {
           equals(200),
         );
         expect(
-          r.context.entry<HttpLinkResponseContext>()!.headers['foo'],
+          r.context.entry<HttpLinkResponseContext>()!.headers!['foo'],
           equals('bar'),
         );
       });
@@ -548,7 +548,7 @@ query WalletGetContent($input: WalletGetContentInput!) {
           equals(200),
         );
         expect(
-          r.context.entry<HttpLinkResponseContext>()!.headers['foo'],
+          r.context.entry<HttpLinkResponseContext>()!.headers!['foo'],
           equals('bar'),
         );
       });
@@ -1443,7 +1443,7 @@ query WalletGetContent($input: WalletGetContentInput!) {
         equals(200),
       );
       expect(
-        r.context.entry<HttpLinkResponseContext>()!.headers['foo'],
+        r.context.entry<HttpLinkResponseContext>()!.headers!['foo'],
         equals('bar'),
       );
     });


### PR DESCRIPTION
With the new version of the compiler, we get some
compiler error that makes the project unable to
complete with success all the checks are done via `make`.

This commit fixes these bugs and make the compiler happy again.

```
 Error: 57 tests passed, 1 failed.
--------------------------------------------------------------------------------

$ melos exec
  └> dart run test --coverage=coverage && dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.dart_tool/package_config.json --report-on=lib
     └> FAILED (in 1 packages)
        └> graphql (with exit code 1)

melos run client_test_coverage
  └> melos exec -- "dart run test --coverage="coverage" && dart run coverage:format_coverage --lcov --in=coverage --out=coverage.lcov --packages=.dart_tool/package_config.json --report-on=lib"
     └> FAILED
ScriptException: The script client_test_coverage failed to execute
make: *** [Makefile:36: ci_coverage_client] Error 1
```

Signed-off-by: Vincenzo Palazzo <vincenzopalazzodev@gmail.com>

<!--
### Breaking changes

- Broke ... because ... .

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated ... .

#### Docs

- Added ... .
- Updated ... .
-->