### PR TITLE
Fixes GraphQLWebSocketChannel missing implementation of ready

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -593,6 +593,8 @@ class GraphQLWebSocketChannel extends StreamChannelMixin<dynamic>
   int? get closeCode => _webSocket.closeCode;
 
   String? get closeReason => _webSocket.closeReason;
+  
+  Future<void> get ready => _webSocket.ready;
 
   @override
   WebSocketSink get sink => _webSocket.sink;


### PR DESCRIPTION
`web_socket_channel` was recently updated to add a `ready` property. This change makes `flutter_graphql` work again.

https://pub.dev/packages/web_socket_channel/changelog#230

Fixes https://github.com/zino-hofmann/graphql-flutter/issues/1282