### PR TITLE
fix(graphql): upgrade the ws packege to v2.3.0

### DIFF
--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -16,7 +16,7 @@ dependencies:
   normalize: ^0.5.3
   http: ^0.13.0
   collection: ^1.15.0
-  web_socket_channel: ^2.0.0
+  web_socket_channel: ^2.3.0
   stream_channel: ^2.1.0
   rxdart: ^0.27.1
   uuid: ^3.0.1


### PR DESCRIPTION
Describe the purpose of the pull request.
<!--
### Breaking changes

- Broke on version 5.0.0 because the web socket package is not updated.

#### Fixes / Enhancements

- Updated package web socket to 2.3.0

#### Docs

- Updated web socket package to 2.3.0
-->