### PR TITLE
fix: added missing onSubscriptionResult argument

### DIFF
--- a/packages/graphql_flutter/lib/src/widgets/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/subscription.dart
@@ -73,6 +73,7 @@ class Subscription<TParsed> extends HookWidget {
       client: client,
       options: options,
       builder: builder,
+      onSubscriptionResult: onSubscriptionResult,
     );
   }
 }


### PR DESCRIPTION
SubscriptionOnClient was missing the SubscriptionOnClient constructor param

Describe the purpose of the pull request.
<!--
### Breaking changes

- Broke ... because ... .

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated ... .

#### Docs

- Added ... .
- Updated ... .
-->