### PR TITLE
feat: bump sdk version upper bound to <4.0.0

### DIFF
--- a/examples/starwars/pubspec.yaml
+++ b/examples/starwars/pubspec.yaml
@@ -4,7 +4,7 @@ description: An example graphql_flutter application utilizing graphql_starwars_t
 publish_to: none
 
 environment:
-  sdk: ">=2.13.0 <=3.0.0"
+  sdk: ">=2.13.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -32,4 +32,4 @@ dev_dependencies:
   lints: ^1.0.1
 
 environment:
-  sdk: '>=2.15.0 <=3.0.0'
+  sdk: '>=2.15.0 <4.0.0'

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -29,7 +29,7 @@ dev_dependencies:
   test: ^1.17.12
 
 environment:
-  sdk: '>=2.12.0 <=3.0.0'
+  sdk: '>=2.12.0 <4.0.0'
   flutter: ">=2.11.0"
 
 platforms:


### PR DESCRIPTION
Make the package available for any Dart SDK versions before 4.0.0
Currently, the package doesn't work with the Dart beta channel (3.1.0)