### PR TITLE
hotfix: fixing the flutter pubspec version

### DIFF
--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/zino-hofmann/graphql-flutter/issues
 # publish_to: 'none'
 
 dependencies:
-  graphql: 5.2.0-beta.5
+  graphql: ^5.2.0-beta.4
   gql_exec: ^1.0.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
The graphql has no reason to be bumped. In fact
this breaks our CI while releasing.

Reported-By: GitHub
Fixes: beb99da9b29c60c3f09172ecff4816f4b0ee4a69

cc @moisessantos
<!--
### Breaking changes

- Broke ... because ... .

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated ... .

#### Docs

- Added ... .
- Updated ... .
-->