### PR TITLE
Send SubscriptionComplete message when using graphqlTransportWs protocol

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -599,6 +599,10 @@ class SocketClient {
           _connectionStateController.value == SocketConnectionState.connected &&
           socketChannel != null) {
         _write(StopOperation(id));
+      } else if (protocol == GraphQLProtocol.graphqlTransportWs &&
+          _connectionStateController.value == SocketConnectionState.connected &&
+          socketChannel != null) {
+        _write(SubscriptionComplete(id));
       }
     };
 


### PR DESCRIPTION
According to the `graphql-transport-ws` [protocol](https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md), when the client is closing a subscription, it is supposed to send a `Complete` message. Currently this library handles sending the `stop` operation for `graphql-ws` protocol, but is not in compliance with the graphql-transport-ws procedure. Consequently, the server does not close it's subscription with the client and resources are being consumed. Therefore, I have added code to provide this proper behavior which tells the server that the client no longer wishes to receive additional message.