### PR TITLE
feat(graphql_flutter): bump connectivity_plus to 5.0.0

### DIFF
--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.7.0
   path_provider: ^2.0.1
   path: ^1.8.0
-  connectivity_plus: ^4.0.0
+  connectivity_plus: ^5.0.0
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
   flutter_hooks: '>=0.18.2 <0.21.0'


### PR DESCRIPTION
- Fixes conflict with upgrading connectivity_plugin to 5.0.0

It seems that there was an issue with the connectivity_plus package's minimum iOS version being set to 11, which caused problems when building on Xcode 15 and iOS 17. Upgrading the package to a newer version should resolve this issue.