### PR TITLE
Don't serialize websocket operations twice

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -576,12 +576,14 @@ class SocketClient {
             .listen((message) => response.addError(message));
 
         if (!_subscriptionInitializers[id]!.hasBeenTriggered) {
-          GraphQLSocketMessage operation = StartOperation(
-            id,
-            serialize(payload),
-          );
+          GraphQLSocketMessage operation;
           if (protocol == GraphQLProtocol.graphqlTransportWs) {
             operation = SubscribeOperation(
+              id,
+              serialize(payload),
+            );
+          } else {
+            operation = StartOperation(
               id,
               serialize(payload),
             );


### PR DESCRIPTION
fix(client): prevent double serialization of operations for websockets

The commit resolves an issue where operations for websockets were being serialized twice when using the "graphql-transport-ws" protocol. This fix removes the redundant serialization step, aligning the process with expected behavior and improving efficiency.

<!--
### Breaking changes

None

#### Fixes / Enhancements

The code was serializing the operation as a `SubscribeOperation`, then checking for the "graphql-transport-ws" protocol and if found serializing it again as a `StartOperation`, throwing away the original.  In our code we are sending an "Authorization" key along with the operation if our token changed.  We only sent it once per change but since this was calling serialize twice the packet containing the token was getting thrown away.

#### Docs

None