### PR TITLE
fix(graphql): bump uuid dependency to ^4.0.0

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -10,8 +10,9 @@ import 'package:graphql/src/utilities/platform.dart';
 import 'package:meta/meta.dart';
 import 'package:rxdart/rxdart.dart';
 import 'package:stream_channel/stream_channel.dart';
+import 'package:uuid/data.dart';
+import 'package:uuid/rng.dart';
 import 'package:uuid/uuid.dart';
-import 'package:uuid/uuid_util.dart';
 import 'package:web_socket_channel/status.dart' as ws_status;
 import 'package:web_socket_channel/web_socket_channel.dart';
 
@@ -26,7 +27,7 @@ typedef WebSocketConnect = FutureOr<WebSocketChannel> Function(
 );
 
 // create uuid generator
-final _uuid = Uuid(options: {'grng': UuidUtil.cryptoRNG});
+final _uuid = Uuid(goptions: GlobalOptions(CryptoRNG()));
 
 class SubscriptionListener {
   Function callback;
@@ -472,10 +473,8 @@ class SocketClient {
     final bool waitForConnection,
   ) {
     final String id = _uuid.v4(
-      options: {
-        'random': randomBytesForUuid,
-      },
-    ).toString();
+      config: V4Options(randomBytesForUuid, null),
+    );
     final StreamController<Response> response = StreamController<Response>();
     StreamSubscription<SocketConnectionState>? sub;
     final bool addTimeout =

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -21,7 +21,7 @@ dependencies:
   web_socket_channel: ^2.3.0
   stream_channel: ^2.1.0
   rxdart: ^0.27.1
-  uuid: ^3.0.1
+  uuid: ^4.0.0
 
 dev_dependencies:
   async: ^2.5.0


### PR DESCRIPTION
fix(graphql): bump uuid dependency to ^4.0.0

Fixes #1391 

The commit update the uuid dependency to version ^4.0.0. 
Uuid class now takes a GlobalOptions class instead of a Map<String, dynamic>.