### PR TITLE
docs(graphql): replace `GraphQL` with `GraphQLClient`

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -128,7 +128,7 @@ which requires a few changes to the above:
 > **NB**: This is different in `graphql_flutter`, which provides `await initHiveForFlutter()` for initialization in `main`
 
 ```dart
-GraphQL getClient() async {
+GraphQLClient getClient() async {
   ...
   /// initialize Hive and wrap the default box in a HiveStore
   final store = await HiveStore.open(path: 'my/cache/path');


### PR DESCRIPTION
### Description
There is a typo in [GraphQL documentation](https://github.com/zino-hofmann/graphql-flutter/blob/main/packages/graphql/README.md), it seems the return type should be `GraphQLClient` instead of `GraphQL`.