### PR TITLE
fix(deps): web_socket_channel broken in ^2.4.1

### DIFF
--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   normalize: ^0.8.2
   http: ^1.0.0
   collection: ^1.15.0
-  web_socket_channel: ^2.3.0
+  web_socket_channel: '>=2.3.0 <=2.4.0'
   stream_channel: ^2.1.0
   rxdart: ^0.27.1
   uuid: ^4.0.0


### PR DESCRIPTION
### Breaking changes

- removes support for web_socket_channel ^2.4.1

#### Fixes / Enhancements

- fixes broken web support: see https://github.com/dart-lang/web_socket_channel/issues/318

#### Docs

- Restricting package [web_socket_channel](https://pub.dev/packages/web_socket_channel) from `^2.3.0` to `>=2.3.0 <=2.4.0` to avoid versions 2.4.1 & 2.4.2 while keeping backward_compatibility

