### PR TITLE
fix(graphql): remove unnecessary null checks in SocketClient

### DIFF
--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -128,7 +128,7 @@ which requires a few changes to the above:
 > **NB**: This is different in `graphql_flutter`, which provides `await initHiveForFlutter()` for initialization in `main`
 
 ```dart
-GraphQL getClient() async {
+GraphQLClient getClient() async {
   ...
   /// initialize Hive and wrap the default box in a HiveStore
   final store = await HiveStore.open(path: 'my/cache/path');

--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -372,8 +372,8 @@ class SocketClient {
   }
 
   void onConnectionLost([Object? e]) async {
-    var code = socketChannel!.closeCode;
-    var reason = socketChannel!.closeReason;
+    var code = socketChannel?.closeCode;
+    var reason = socketChannel?.closeReason;
 
     await _closeSocketChannel();
     if (e != null) {


### PR DESCRIPTION
**Fixes**

- Removed unnecessary null checks(!) on SocketChannel instance in SocketClient onConnectionLost() method which cause an error when client cannot connect (https://github.com/zino-hofmann/graphql-flutter/issues/1379). this prevents reconnecting when there is a working connection later.
