### PR TITLE
Address null check error and prevent duplicate events on socket reconnect

### DIFF
--- a/packages/graphql/lib/src/core/fetch_more.dart
+++ b/packages/graphql/lib/src/core/fetch_more.dart
@@ -34,11 +34,11 @@ Future<QueryResult<TParsed>> fetchMoreImplementation<TParsed>(
     final data = fetchMoreOptions.updateQuery(
       previousResult.data,
       fetchMoreResult.data,
-    )!;
+    );
 
     fetchMoreResult.data = data;
 
-    if (originalOptions.fetchPolicy != FetchPolicy.noCache) {
+    if (originalOptions.fetchPolicy != FetchPolicy.noCache && data != null) {
       queryManager.attemptCacheWriteFromClient(
         request,
         data,

--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -502,6 +502,7 @@ class SocketClient {
             )
           : waitForConnectedStateWithoutTimeout;
 
+      sub?.cancel();
       sub = waitForConnectedState.listen((_) {
         final Stream<GraphQLSocketMessage> dataErrorComplete = _messages.where(
           (GraphQLSocketMessage message) {

--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -372,8 +372,8 @@ class SocketClient {
   }
 
   void onConnectionLost([Object? e]) async {
-    var code = socketChannel!.closeCode;
-    var reason = socketChannel!.closeReason;
+    var code = socketChannel?.closeCode;
+    var reason = socketChannel?.closeReason;
 
     await _closeSocketChannel();
     if (e != null) {


### PR DESCRIPTION
**Fixes**
- Removed unnecessary null checks(!) on SocketChannel instance in SocketClient `onConnectionLost()` method which cause an error when client cannot connect (#1379). this prevents reconnecting when there is a working connection later.
-  Resolved an issue in WebSocketClient where multiple listeners were added to `waitForConnectedState` when socket reconnects after subscription been requtesed with disconnected socket, causing duplicate events to be received by subscriptions (#989) (thanks to @stardarLeung).
- Fixed an issue in `fetchMore` where results were not added to the stream when `fetchMoreOptions.updateQuery` returned null.