### PR TITLE
fix: response extensions should be optional

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_messages.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_messages.dart
@@ -263,7 +263,7 @@ class SubscriptionData extends GraphQLSocketMessage {
         "type": type,
         "data": data,
         "errors": errors,
-        "extensions": extensions,
+        if (extensions != null) "extensions": extensions,
       };
 
   @override
@@ -288,7 +288,7 @@ class SubscriptionNext extends GraphQLSocketMessage {
         "type": type,
         "data": data,
         "errors": errors,
-        "extensions": extensions,
+        if (extensions != null) "extensions": extensions,
       };
 
   @override

--- a/packages/graphql/lib/src/links/websocket_link/websocket_messages.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_messages.dart
@@ -270,7 +270,7 @@ class SubscriptionData extends GraphQLSocketMessage {
   int get hashCode => toJson().hashCode;
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is SubscriptionData && jsonEncode(other) == jsonEncode(this);
 }
 
@@ -295,7 +295,7 @@ class SubscriptionNext extends GraphQLSocketMessage {
   int get hashCode => toJson().hashCode;
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is SubscriptionNext && jsonEncode(other) == jsonEncode(this);
 }
 

--- a/packages/graphql/test/websocket_test.dart
+++ b/packages/graphql/test/websocket_test.dart
@@ -229,6 +229,59 @@ Future<void> main() async {
         ),
       );
     });
+    test('subscription data with extensions', () async {
+      final payload = Request(
+        operation: Operation(document: parseString('subscription {}')),
+      );
+      final waitForConnection = true;
+      final subscriptionDataStream =
+          socketClient.subscribe(payload, waitForConnection);
+      await socketClient.connectionState
+          .where((state) => state == SocketConnectionState.connected)
+          .first;
+
+      // ignore: unawaited_futures
+      socketClient.socketChannel!.stream
+          .where((message) => message == expectedMessage)
+          .first
+          .then((_) {
+        socketClient.socketChannel!.sink.add(jsonEncode({
+          'type': 'data',
+          'id': '01020304-0506-4708-890a-0b0c0d0e0f10',
+          'payload': {
+            'data': {'foo': 'bar'},
+            'errors': [
+              {'message': 'error and data can coexist'}
+            ],
+            'extensions': {'extensionKey': 'extensionValue'},
+          }
+        }));
+      });
+
+      await expectLater(
+        subscriptionDataStream,
+        emits(
+          // todo should ids be included in response context? probably '01020304-0506-4708-890a-0b0c0d0e0f10'
+          Response(
+            data: {'foo': 'bar'},
+            errors: [
+              GraphQLError(message: 'error and data can coexist'),
+            ],
+            context: Context().withEntry(ResponseExtensions(<dynamic, dynamic>{
+              'extensionKey': 'extensionValue',
+            })),
+            response: {
+              "type": "data",
+              "data": {"foo": "bar"},
+              "errors": [
+                {"message": "error and data can coexist"}
+              ],
+              "extensions": {'extensionKey': 'extensionValue'},
+            },
+          ),
+        ),
+      );
+    });
     test('resubscribe', () async {
       final payload = Request(
         operation: Operation(document: gql('subscription {}')),


### PR DESCRIPTION
#1394 made SubscriptionData json always containing extensions. Now extensions in json are only present if response contained them.