### PR TITLE
fix(graphql): transform nested object from box

### DIFF
--- a/packages/graphql/lib/src/cache/hive_store.dart
+++ b/packages/graphql/lib/src/cache/hive_store.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
-import 'package:meta/meta.dart';
 
 import 'package:hive/hive.dart';
+import 'package:meta/meta.dart';
 
 import './store.dart';
 
@@ -92,7 +92,15 @@ class HiveStore extends Store {
   }
 
   @override
-  Map<String, Map<String, dynamic>?> toMap() => Map.unmodifiable(box.toMap());
+  Map<String, Map<String, dynamic>?> toMap() {
+    final map = <String, Map<String, dynamic>?>{};
+    for (final key in box.keys) {
+      if (key is String) {
+        map[key] = get(key);
+      }
+    }
+    return Map.unmodifiable(map);
+  }
 
   Future<void> reset() => box.clear();
 }

--- a/packages/graphql/test/cache/store_test.dart
+++ b/packages/graphql/test/cache/store_test.dart
@@ -121,6 +121,28 @@ void main() {
         expect(readData2?['bob'], isA<List<dynamic>>());
         expect(readData2?['bob'][0], isA<Map<String, dynamic>>());
       });
+      test("Can re-open and reference nested data", () async {
+        final box1 = await HiveStore.openBox(
+          're-open-store',
+          path: path,
+        );
+        final store = HiveStore(box1);
+        final data = {
+          'foo': 'bar',
+          'bob': [
+            {'nested': true}
+          ]
+        };
+        store.put("id", data);
+        expect(store.toMap(), equals({'id': data}));
+        await box1.close();
+        final box2 = await HiveStore.openBox(
+          're-open-store',
+          path: path,
+        );
+        final store2 = HiveStore(box2);
+        expect(store2.toMap(), equals({'id': data}));
+      });
       test("Can put null", () async {
         final box1 = await HiveStore.openBox(
           'put-null',


### PR DESCRIPTION
When the HiveStore is reopened and `HiveStore#toMap` is used, the following error occurs:

```
type '_Map<dynamic, dynamic>' is not a subtype of type 'Map<String, dynamic>?' in type cast
```

The related issue is #1091 and the pull request is #1167.
I believe `HiveStore#toMap` should also recursively transform nested objects.