### PR TITLE
feat: upgraded connectivity_plus package

### DIFF
--- a/packages/graphql_flutter/lib/src/widgets/hooks/subscription.dart
+++ b/packages/graphql_flutter/lib/src/widgets/hooks/subscription.dart
@@ -69,8 +69,9 @@ class _SubscriptionHookState<TParsed> extends HookState<
     Stream<QueryResult<TParsed>>, _SubscriptionHook<TParsed>> {
   late Stream<QueryResult<TParsed>> stream;
 
-  ConnectivityResult? _currentConnectivityResult;
-  StreamSubscription<ConnectivityResult>? _networkSubscription;
+  // ConnectivityResult? _currentConnectivityResult;
+  List<ConnectivityResult> _currentConnectivityResult = [ConnectivityResult.none];
+  StreamSubscription<List<ConnectivityResult>>? _networkSubscription;
 
   void _initSubscription() {
     final client = hook.client;
@@ -107,7 +108,7 @@ class _SubscriptionHookState<TParsed> extends HookState<
     super.dispose();
   }
 
-  Future<void> _onNetworkChange(ConnectivityResult result) async {
+  Future<void> _onNetworkChange(List<ConnectivityResult> result) async {
     //if from offline to online
     if (_currentConnectivityResult == ConnectivityResult.none &&
         (result == ConnectivityResult.mobile ||
@@ -125,7 +126,7 @@ class _SubscriptionHookState<TParsed> extends HookState<
           }
           // on exception -> no real connection, set current state to none
         } on SocketException catch (_) {
-          _currentConnectivityResult = ConnectivityResult.none;
+          _currentConnectivityResult = [ConnectivityResult.none];
         }
       } else {
         _initSubscription();

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -15,7 +15,6 @@ dependencies:
   meta: ^1.7.0
   path_provider: ^2.0.1
   path: ^1.8.0
-  #connectivity_plus: ^5.0.0
   connectivity_plus: ^6.0.2
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.7.0
   path_provider: ^2.0.1
   path: ^1.8.0
-  connectivity_plus: ^3.0.0
+  connectivity_plus: ^6.0.2
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
   flutter_hooks: ^0.18.2

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   meta: ^1.7.0
   path_provider: ^2.0.1
   path: ^1.8.0
+  #connectivity_plus: ^5.0.0
   connectivity_plus: ^6.0.2
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
@@ -29,8 +30,8 @@ dev_dependencies:
   test: ^1.17.12
 
 environment:
-  sdk: '>=2.12.0 <=3.0.0'
-  flutter: ">=2.11.0"
+  sdk: '>=3.3.0 <=4.0.0'
+  flutter: ">=3.19.5"
 
 platforms:
   android:


### PR DESCRIPTION

- As app store introduced mandatory privacy manifest files for some of packages being used in the application. connectivity_plus 6.0.2 is one of them and current version of connectivity_plus 6.0.2 has added support for privacy manifest but graphql_flutter still using connectivity_plus 5.0.0 which leads into compatibility issue. App store is very specific about the deadline of these as well which is 1st of may.;



upgraded connectivity_plus from 5.0.0 to 6.0.2

Please merge this on priority as this breaking changes is needed for all the flutter application which is using connectivity_plus 6.0.2 along with graphql_flutter

Fixes https://github.com/zino-hofmann/graphql-flutter/issues/1423#issuecomment-2052495874
