### PR TITLE
fix(graphql_flutter): upgrade dependency `connectivity_plus`

### DIFF
--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.7.0
   path_provider: ^2.0.1
   path: ^1.8.0
-  connectivity_plus: ^5.0.0
+  connectivity_plus: ^6.0.1
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
   flutter_hooks: '>=0.18.2 <0.21.0'


### PR DESCRIPTION
Upgrades dependency [connectivity_plus](https://pub.dev/packages/connectivity_plus)  to its next major version (^6.0.1). 

This will be helpful for projects that depend on both `connectivity_plus` and `graphql_flutter` to keep their dependencies up-to-date. Without this upgrade here, downstream projects could have a dependency conflict between `connectivity_plus` `^5.0.0` and `^6.0.1`.

#### Fixes / Enhancements

- Updated dependency [connectivity_plus](https://pub.dev/packages/connectivity_plus)
