### PR TITLE
feat(graphql): Support custom equality function for cache comparison

### DIFF
--- a/packages/graphql/lib/client.dart
+++ b/packages/graphql/lib/client.dart
@@ -9,4 +9,5 @@ export 'package:graphql/src/graphql_client.dart';
 
 export 'package:graphql/src/links/links.dart';
 
-export 'package:graphql/src/utilities/helpers.dart' show gql;
+export 'package:graphql/src/utilities/helpers.dart'
+    show gql, optimizedDeepEquals;

--- a/packages/graphql/lib/src/cache/fragment.dart
+++ b/packages/graphql/lib/src/cache/fragment.dart
@@ -1,10 +1,10 @@
 import 'dart:convert';
+import "package:graphql/client.dart";
 import "package:meta/meta.dart";
 import "package:collection/collection.dart";
 
 import "package:gql/ast.dart";
 import 'package:gql/language.dart';
-import "package:gql_exec/gql_exec.dart";
 import 'package:normalize/utils.dart';
 
 /// A fragment in a [document], optionally defined by [fragmentName]
@@ -32,9 +32,7 @@ class Fragment {
   bool operator ==(Object o) =>
       identical(this, o) ||
       (o is Fragment &&
-          const ListEquality<Object?>(
-            DeepCollectionEquality(),
-          ).equals(
+          gqlDeepEquals(
             o._getChildren(),
             _getChildren(),
           ));
@@ -89,9 +87,7 @@ class FragmentRequest {
   bool operator ==(Object o) =>
       identical(this, o) ||
       (o is FragmentRequest &&
-          const ListEquality<Object?>(
-            DeepCollectionEquality(),
-          ).equals(
+          gqlDeepEquals(
             o._getChildren(),
             _getChildren(),
           ));

--- a/packages/graphql/lib/src/core/_base_options.dart
+++ b/packages/graphql/lib/src/core/_base_options.dart
@@ -104,9 +104,7 @@ abstract class BaseOptions<TParsed extends Object?> {
       identical(this, other) ||
       (other is BaseOptions &&
           runtimeType == other.runtimeType &&
-          const ListEquality<Object?>(
-            DeepCollectionEquality(),
-          ).equals(
+          gqlDeepEquals(
             other.properties,
             properties,
           ));

--- a/packages/graphql/lib/src/core/policies.dart
+++ b/packages/graphql/lib/src/core/policies.dart
@@ -307,9 +307,7 @@ class DefaultPolicies {
   bool operator ==(Object o) =>
       identical(this, o) ||
       (o is DefaultPolicies &&
-          const ListEquality<Object?>(
-            DeepCollectionEquality(),
-          ).equals(
+          gqlDeepEquals(
             o._getChildren(),
             _getChildren(),
           ));

--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -26,12 +26,14 @@ class GraphQLClient implements GraphQLDataProxy {
     required this.cache,
     DefaultPolicies? defaultPolicies,
     bool alwaysRebroadcast = false,
+    DeepEqualsFn? deepEquals,
     bool deduplicatePollers = false,
   })  : defaultPolicies = defaultPolicies ?? DefaultPolicies(),
         queryManager = QueryManager(
           link: link,
           cache: cache,
           alwaysRebroadcast: alwaysRebroadcast,
+          deepEquals: deepEquals,
           deduplicatePollers: deduplicatePollers,
         );
 

--- a/packages/graphql/lib/src/utilities/helpers.dart
+++ b/packages/graphql/lib/src/utilities/helpers.dart
@@ -90,3 +90,46 @@ SanitizeVariables variableSanitizer(
                 toEncodable: sanitizeVariables,
               ),
             ) as Map<String, dynamic>;
+
+/// Compare two json-like objects for equality
+/// [a] and [b] must be one of
+/// - null
+/// - num
+/// - bool
+/// - String
+/// - List of above types
+/// - Map of above types
+///
+/// This is an alternative too [DeepCollectionEquality().equals],
+/// which is very slow and has O(n^2) complexity:
+bool optimizedDeepEquals(Object? a, Object? b) {
+  if (identical(a, b)) {
+    return true;
+  }
+  if (a == b) {
+    return true;
+  }
+  if (a is Map) {
+    if (b is! Map) {
+      return false;
+    }
+    if (a.length != b.length) return false;
+    for (var key in a.keys) {
+      if (!b.containsKey(key)) return false;
+      if (!optimizedDeepEquals(a[key], b[key])) return false;
+    }
+    return true;
+  }
+  if (a is List) {
+    if (b is! List) {
+      return false;
+    }
+    final length = a.length;
+    if (length != b.length) return false;
+    for (var i = 0; i < length; i++) {
+      if (!optimizedDeepEquals(a[i], b[i])) return false;
+    }
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
Summary
- The current equality check has received some dissatisfaction due to performance (and is a source of jank/missed frames in my application)
- This is an unopinionated way to allow those consumers to provide their own equality function with better performance

Details
- Fixes: https://github.com/zino-hofmann/graphql-flutter/issues/1315
- Improves: https://github.com/zino-hofmann/graphql-flutter/issues/424
- The default in this package is `const DeepCollectionEquality().equals`
- You can now optionally provide your own (an example one is included based on [this answer](https://github.com/zino-hofmann/graphql-flutter/issues/424#issuecomment-1418835283))
- From my testing, writing a simple fragment with 10 other observables, it takes 150ms (on the main thread) vs 30ms (with the `optimizedDeepEquals`)