### PR TITLE
fix(graphql): fix error is throwed when toggleConnection != null & fix(graphql_flutter): upgrate connectivity_plus

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -215,7 +215,8 @@ class SocketClient {
   final SocketClientConfig config;
 
   final BehaviorSubject<SocketConnectionState> _connectionStateController =
-      BehaviorSubject<SocketConnectionState>();
+      BehaviorSubject<SocketConnectionState>.seeded(
+          SocketConnectionState.notConnected);
 
   final HashMap<String, SubscriptionListener> _subscriptionInitializers =
       HashMap();

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.7.0
   path_provider: ^2.0.1
   path: ^1.8.0
-  connectivity_plus: ^6.0.1
+  connectivity_plus: ^6.0.3
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
   flutter_hooks: '>=0.18.2 <0.21.0'


### PR DESCRIPTION
1. **[graphql] fix error is throwed (althought it doesn't  make any crash) when toggleConnection != null**

```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: ValueStream has no value. You should check ValueStream.hasValue before accessing ValueStream.value, or use ValueStream.valueOrNull instead.
      BehaviorSubject.value (package:rxdart/src/subjects/behavior_subject.dart:146:5)
      SocketClient._listenToToggleConnection.<anonymous closure> (package:graphql/src/links/websocket_link/websocket_client.dart:264:40)
      _RootZone.runUnaryGuarded (dart:async/zone.dart:1594:10)
      _BufferingStreamSubscription._sendData (dart:async/stream_impl.dart:339:11)
      _BufferingStreamSubscription._add (dart:async/stream_impl.dart:271:7)
      _MultiStreamController.addSync (dart:async/stream_impl.dart:1101:36)
      _MultiControllerSink.add (package:rxdart/src/utils/forwarding_stream.dart:130:35)
      _TakeUntilStreamSink.onData (package:rxdart/src/transformers/take_until.dart:13:31)
```

2. **[graphql_flutter] upgrate connectivity_plus: ^6.0.3**

2 important commits:
+ v6.0.2: https://github.com/fluttercommunity/plus_plugins/pull/2763
+ v6.0.3: https://github.com/fluttercommunity/plus_plugins/pull/2836