### PR TITLE
Fix GraphQLProtocol documentation

### DIFF
--- a/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
+++ b/packages/graphql/lib/src/links/websocket_link/websocket_client.dart
@@ -176,15 +176,13 @@ class SocketSubProtocol {
 class GraphQLProtocol {
   GraphQLProtocol._();
 
-  /// graphql-ws: The new  (not to be confused with the graphql-ws library).
+  /// graphql-ws: Old protocol (not to be confused with the graphql-ws library).
   /// NB. This protocol is it no longer maintained, please consider
   /// to use `SocketSubProtocol.graphqlTransportWs`.
   static const String graphqlWs = "graphql-ws";
 
-  /// graphql-transport-ws: New ws protocol used by most Apollo Server instances
-  /// with subscriptions enabled use this library.
-  /// N.B: not to be confused with the graphql-ws library that implement the
-  /// old ws protocol.
+  /// graphql-transport-ws: New protocol used by most Apollo Server instances
+  /// with subscriptions enabled. Implemented by the graphql-ws library.
   static const String graphqlTransportWs = "graphql-transport-ws";
 }
 


### PR DESCRIPTION
#### Docs

The graphql-ws library does implement the graphql-transport-ws now.
See their readme: https://github.com/enisdenjo/graphql-ws/blob/master/PROTOCOL.md#communication
"The WebSocket sub-protocol for this specification is: graphql-transport-ws."

- Updated the description of the GraphQLProtocol to be current.


#### Suggestions

Should we update the default protocol for SocketClientConfig to SocketSubProtocol.graphqlTransportWs?