### PR TITLE
fix(graphql): add timeout to _resolveQueryOnNetwork

### DIFF
--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -244,7 +244,8 @@ class QueryManager {
 
     try {
       // execute the request through the provided link(s)
-      response = await link.request(request).first;
+      response =
+          await link.request(request).timeout(Duration(seconds: 5)).first;
 
       queryResult = mapFetchResultToQueryResult(
         response,


### PR DESCRIPTION
#### Fixes
- Fixed an issue where an await would not come if WebsocketLink was disposed before the query was executed.
- Please comment on the timeout time of 5 seconds, as we have not been able to determine whether it is appropriate.
