### PR TITLE
[graphql] [chore]: update normalize dependency to version 0.9.1

### DIFF
--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   gql_error_link: ^1.0.0
   gql_dedupe_link: ^2.0.3
   hive: ^2.1.0
-  normalize: ^0.9.1
+  normalize: '>=0.8.2 <0.10.0'
   http: ^1.0.0
   collection: ^1.15.0
   web_socket_channel: '>=2.3.0 <=2.4.0'

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   gql_error_link: ^1.0.0
   gql_dedupe_link: ^2.0.3
   hive: ^2.1.0
-  normalize: ^0.8.2
+  normalize: ^0.9.1
   http: ^1.0.0
   collection: ^1.15.0
   web_socket_channel: '>=2.3.0 <=2.4.0'


### PR DESCRIPTION
The main branch is incompatible with ferry which requires normalize 0.9.1.
