### PR TITLE
chore(graphql): upgrade rxdart 0.28.0

### DIFF
--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   collection: ^1.15.0
   web_socket_channel: '>=2.3.0 <=2.4.0'
   stream_channel: ^2.1.0
-  rxdart: ^0.28.0
+  rxdart: '>=0.27.1 <0.29.0'
   uuid: ^4.0.0
 
 dev_dependencies:

--- a/packages/graphql/pubspec.yaml
+++ b/packages/graphql/pubspec.yaml
@@ -20,7 +20,7 @@ dependencies:
   collection: ^1.15.0
   web_socket_channel: '>=2.3.0 <=2.4.0'
   stream_channel: ^2.1.0
-  rxdart: ^0.27.1
+  rxdart: ^0.28.0
   uuid: ^4.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Fixes #1441

Upgrade rxdart to 0.28.0.
Newer version might not affect any changes to this package.

- [rxdart changelog | Dart package](https://pub.dev/packages/rxdart/changelog)