### PR TITLE
feat(graphql_common): Add `deduplicatePollers`, `deepEquals`, and `queryRequestTimeout` parameters to `copyWith` method in `GraphQLClient`

### DIFF
--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -56,6 +56,8 @@ class GraphQLClient implements GraphQLDataProxy {
     GraphQLCache? cache,
     DefaultPolicies? defaultPolicies,
     bool? alwaysRebroadcast,
+    DeepEqualsFn? deepEquals,
+    bool deduplicatePollers = false,
     Duration? queryRequestTimeout,
   }) {
     return GraphQLClient(
@@ -63,6 +65,8 @@ class GraphQLClient implements GraphQLDataProxy {
       cache: cache ?? this.cache,
       defaultPolicies: defaultPolicies ?? this.defaultPolicies,
       alwaysRebroadcast: alwaysRebroadcast ?? queryManager.alwaysRebroadcast,
+      deepEquals: deepEquals,
+      deduplicatePollers: deduplicatePollers,
       queryRequestTimeout: queryRequestTimeout ?? queryManager.requestTimeout,
     );
   }

--- a/packages/graphql/test/graphql_client_test.dart
+++ b/packages/graphql/test/graphql_client_test.dart
@@ -1447,5 +1447,105 @@ query WalletGetContent($input: WalletGetContentInput!) {
         equals('bar'),
       );
     });
+
+    group('GraphQLClient copyWith', () {
+      late GraphQLClient client;
+      late Link link;
+      late GraphQLCache cache;
+      late DefaultPolicies defaultPolicies;
+      late Duration queryRequestTimeout;
+
+      setUp(() {
+        link = MockLink();
+        cache = GraphQLCache();
+        defaultPolicies = DefaultPolicies();
+        queryRequestTimeout = const Duration(seconds: 5);
+        client = GraphQLClient(
+          link: link,
+          cache: cache,
+          defaultPolicies: defaultPolicies,
+          queryRequestTimeout: queryRequestTimeout,
+        );
+      });
+
+      test('copyWith updates link', () {
+        final newLink = MockLink();
+        final newClient = client.copyWith(link: newLink);
+
+        expect(newClient.link, equals(newLink));
+        expect(newClient.cache, equals(client.cache));
+        expect(newClient.defaultPolicies, equals(client.defaultPolicies));
+        expect(
+          newClient.queryManager.requestTimeout,
+          equals(client.queryManager.requestTimeout),
+        );
+      });
+
+      test('copyWith updates cache', () {
+        final newCache = GraphQLCache();
+        final newClient = client.copyWith(cache: newCache);
+
+        expect(newClient.cache, equals(newCache));
+        expect(newClient.link, equals(client.link));
+        expect(newClient.defaultPolicies, equals(client.defaultPolicies));
+        expect(
+          newClient.queryManager.requestTimeout,
+          equals(client.queryManager.requestTimeout),
+        );
+      });
+
+      test('copyWith updates defaultPolicies', () {
+        final newDefaultPolicies = DefaultPolicies();
+        final newClient = client.copyWith(defaultPolicies: newDefaultPolicies);
+
+        expect(newClient.defaultPolicies, equals(newDefaultPolicies));
+        expect(newClient.link, equals(client.link));
+        expect(newClient.cache, equals(client.cache));
+        expect(
+          newClient.queryManager.requestTimeout,
+          equals(client.queryManager.requestTimeout),
+        );
+      });
+
+      test('copyWith updates alwaysRebroadcast', () {
+        final newClient = client.copyWith(alwaysRebroadcast: true);
+
+        expect(newClient.queryManager.alwaysRebroadcast, isTrue);
+        expect(newClient.link, equals(client.link));
+        expect(newClient.cache, equals(client.cache));
+        expect(newClient.defaultPolicies, equals(client.defaultPolicies));
+        expect(
+          newClient.queryManager.requestTimeout,
+          equals(client.queryManager.requestTimeout),
+        );
+      });
+
+      test('copyWith updates queryRequestTimeout', () {
+        final newTimeout = const Duration(seconds: 10);
+        final newClient = client.copyWith(queryRequestTimeout: newTimeout);
+
+        expect(newClient.queryManager.requestTimeout, equals(newTimeout));
+        expect(newClient.link, equals(client.link));
+        expect(newClient.cache, equals(client.cache));
+        expect(newClient.defaultPolicies, equals(client.defaultPolicies));
+      });
+
+      test('copyWith does not override any properties if none are provided',
+          () {
+        final newClient = client.copyWith();
+
+        expect(newClient.link, equals(client.link));
+        expect(newClient.cache, equals(client.cache));
+        expect(newClient.defaultPolicies, equals(client.defaultPolicies));
+        expect(
+          newClient.queryManager.alwaysRebroadcast,
+          equals(client.queryManager.alwaysRebroadcast),
+        );
+        expect(
+          newClient.queryManager.requestTimeout,
+          equals(client.queryManager.requestTimeout),
+        );
+      });
+    });
   });
 }


### PR DESCRIPTION
**Summary:**
This PR adds `deduplicatePollers`, `deepEquals`, and `queryRequestTimeout` parameters to the `copyWith` method in the `GraphQLClient` class. Including these parameters in `copyWith` allows for more consistent client cloning.

**Justification:**
Adding `deduplicatePollers`, `deepEquals`, and `queryRequestTimeout` parameters addresses a potential inconsistency in cloned instances.
For example, the timeout might differ unexpectedly from the base client configuration. Without this cloned instances would always initialize with a `5-second timeout`, which may lead to unanticipated request behavior.