### PR TITLE
Fixed: add queryRequestTimeout to copyWith method 

### DIFF
--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -51,16 +51,20 @@ class GraphQLClient implements GraphQLDataProxy {
   late final QueryManager queryManager;
 
   /// Create a copy of the client with the provided information.
-  GraphQLClient copyWith(
-      {Link? link,
-      GraphQLCache? cache,
-      DefaultPolicies? defaultPolicies,
-      bool? alwaysRebroadcast}) {
+  GraphQLClient copyWith({
+    Link? link,
+    GraphQLCache? cache,
+    DefaultPolicies? defaultPolicies,
+    bool? alwaysRebroadcast,
+    Duration? queryRequestTimeout,
+  }) {
     return GraphQLClient(
-        link: link ?? this.link,
-        cache: cache ?? this.cache,
-        defaultPolicies: defaultPolicies ?? this.defaultPolicies,
-        alwaysRebroadcast: alwaysRebroadcast ?? queryManager.alwaysRebroadcast);
+      link: link ?? this.link,
+      cache: cache ?? this.cache,
+      defaultPolicies: defaultPolicies ?? this.defaultPolicies,
+      alwaysRebroadcast: alwaysRebroadcast ?? queryManager.alwaysRebroadcast,
+      queryRequestTimeout: queryRequestTimeout ?? queryManager.requestTimeout,
+    );
   }
 
   /// This registers a query in the [QueryManager] and returns an [ObservableQuery]


### PR DESCRIPTION
There are some simple steps to get your PR merged, that are the following:

- Describe your PR and why a maintainer should merge it;
The PR adds the queryRequestTimeout to the copyWith method
- Put the same description inside the commit body otherwise if we change github hosting you application will be based on a instable source code;
- Write the commit header in the way that it is following these simple rules [1]
- Make sure that your PR will pass the CI
- Wait for an review :smile: that will not happen if one of the previous step is missing.

[1](https://github.com/zino-hofmann/graphql-flutter/blob/main/docs/dev/MAINTAINERS.md#commit-style)

<!--
### Breaking changes

- Broke ... because ... .

#### Fixes / Enhancements

- Fixed ... was ... .
- Added ... .
- Updated ... .

#### Docs

- Added ... .
- Updated ... .
-->
