### PR TITLE
feat(graphql): Make gql query timeout optional

### DIFF
--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -53,7 +53,7 @@ class QueryManager {
   final bool alwaysRebroadcast;
 
   /// The timeout for resolving a query
-  final Duration requestTimeout;
+  final Duration? requestTimeout;
 
   QueryScheduler? scheduler;
   static final _oneOffOpId = '0';
@@ -260,7 +260,12 @@ class QueryManager {
 
     try {
       // execute the request through the provided link(s)
-      response = await link.request(request).timeout(this.requestTimeout).first;
+      final requestTimeout = this.requestTimeout;
+      if (requestTimeout != null) {
+        response = await link.request(request).timeout(requestTimeout).first;
+      } else {
+        response = await link.request(request).first;
+      }
 
       queryResult = mapFetchResultToQueryResult(
         response,

--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -28,7 +28,7 @@ class GraphQLClient implements GraphQLDataProxy {
     bool alwaysRebroadcast = false,
     DeepEqualsFn? deepEquals,
     bool deduplicatePollers = false,
-    Duration queryRequestTimeout = const Duration(seconds: 5),
+    Duration? queryRequestTimeout = const Duration(seconds: 5),
   })  : defaultPolicies = defaultPolicies ?? DefaultPolicies(),
         queryManager = QueryManager(
           link: link,


### PR DESCRIPTION
## Problem

The latest version of the graphql package enforces a timeout on its queries.

## Solution

Make the request timeout duration optional, and if omitted, will not invoke `timeout` on the query request stream.

## Why

We prefer to let our underlying http library (Dio) handle our timeouts, and as such decouple the responsibility from the gql client itself.

Not only does this let us define timeout logic in one place (the Dio config) and share it with non-gql requests, but it also vastly simplifies our unit testing story. We only mock our Dio client (and not the gql client itself), which effectively lets us build a testing story as close to production as possible. I couldn't for the life of me figure out how to adapt our unit tests to accommodate `.timeout` injected within the gql client itself. (The unit test failures were basically "a timer still exists" even though the requests have already finished.)

## The workaround before this PR

Because our unit testing uses the gql client itself (instead of mocking it), bumping to the latest beta version of this package started failing basically every unit test.

See: https://github.com/zino-hofmann/graphql-flutter/issues/1457

To get around this, we basically hijacked the pub cache to force a custom patch that removes `.timeout` entirely. We can remove this patch if this PR is merged.