### PR TITLE
feat(graphql) make timeout configurable in query options

### DIFF
--- a/packages/graphql/lib/src/core/_base_options.dart
+++ b/packages/graphql/lib/src/core/_base_options.dart
@@ -23,6 +23,7 @@ abstract class BaseOptions<TParsed extends Object?> {
     ErrorPolicy? errorPolicy,
     CacheRereadPolicy? cacheRereadPolicy,
     this.optimisticResult,
+    this.queryRequestTimeout,
   })  : policies = Policies(
           fetch: fetchPolicy,
           error: errorPolicy,
@@ -60,6 +61,9 @@ abstract class BaseOptions<TParsed extends Object?> {
 
   final ResultParserFn<TParsed> parserFn;
 
+  /// Override default query timeout
+  final Duration? queryRequestTimeout;
+
   // TODO consider inverting this relationship
   /// Resolve these options into a request
   Request get asRequest => Request(
@@ -80,6 +84,7 @@ abstract class BaseOptions<TParsed extends Object?> {
         policies,
         context,
         parserFn,
+        queryRequestTimeout,
       ];
 
   OperationType get type {

--- a/packages/graphql/lib/src/core/mutation_options.dart
+++ b/packages/graphql/lib/src/core/mutation_options.dart
@@ -30,6 +30,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
     this.update,
     this.onError,
     ResultParserFn<TParsed>? parserFn,
+    Duration? queryRequestTimeout,
   }) : super(
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -40,6 +41,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
           context: context,
           optimisticResult: optimisticResult,
           parserFn: parserFn,
+          queryRequestTimeout: queryRequestTimeout,
         );
 
   final OnMutationCompleted? onCompleted;
@@ -68,6 +70,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         update: update,
         onError: onError,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
       );
 
   WatchQueryOptions<TParsed> asWatchQueryOptions() =>
@@ -81,6 +84,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         fetchResults: false,
         context: context,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
       );
 }
 

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -27,6 +27,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
     this.pollInterval,
     Context? context,
     ResultParserFn<TParsed>? parserFn,
+    Duration? queryRequestTimeout,
     this.onComplete,
     this.onError,
   }) : super(
@@ -39,6 +40,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
           context: context,
           optimisticResult: optimisticResult,
           parserFn: parserFn,
+          queryRequestTimeout: queryRequestTimeout,
         );
 
   final OnQueryComplete? onComplete;
@@ -68,6 +70,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
     Duration? pollInterval,
     Context? context,
     ResultParserFn<TParsed>? parserFn,
+    Duration? queryRequestTimeout,
     OnQueryComplete? onComplete,
     OnQueryError? onError,
   }) =>
@@ -82,6 +85,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         pollInterval: pollInterval ?? this.pollInterval,
         context: context ?? this.context,
         parserFn: parserFn ?? this.parserFn,
+        queryRequestTimeout: queryRequestTimeout ?? this.queryRequestTimeout,
         onComplete: onComplete ?? this.onComplete,
         onError: onError ?? this.onError,
       );
@@ -95,6 +99,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         fetchPolicy: FetchPolicy.noCache,
         errorPolicy: errorPolicy,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
         context: context,
         variables: {
           ...variables,
@@ -115,6 +120,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         context: context,
         optimisticResult: optimisticResult,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
       );
 
   QueryOptions<TParsed> copyWithPolicies(Policies policies) => QueryOptions(
@@ -128,6 +134,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         pollInterval: pollInterval,
         context: context,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
       );
 }
 
@@ -144,6 +151,7 @@ class SubscriptionOptions<TParsed extends Object?>
     Object? optimisticResult,
     Context? context,
     ResultParserFn<TParsed>? parserFn,
+    Duration? queryRequestTimeout,
   }) : super(
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -154,6 +162,7 @@ class SubscriptionOptions<TParsed extends Object?>
           context: context,
           optimisticResult: optimisticResult,
           parserFn: parserFn,
+          queryRequestTimeout: queryRequestTimeout,
         );
   SubscriptionOptions<TParsed> copyWithPolicies(Policies policies) =>
       SubscriptionOptions(
@@ -166,6 +175,7 @@ class SubscriptionOptions<TParsed extends Object?>
         optimisticResult: optimisticResult,
         context: context,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
       );
 }
 
@@ -185,6 +195,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
     bool? eagerlyFetchResults,
     Context? context,
     ResultParserFn<TParsed>? parserFn,
+    Duration? queryRequestTimeout,
   })  : eagerlyFetchResults = eagerlyFetchResults ?? fetchResults,
         super(
           document: document,
@@ -197,6 +208,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
           context: context,
           optimisticResult: optimisticResult,
           parserFn: parserFn,
+          queryRequestTimeout: queryRequestTimeout,
         );
 
   /// Whether or not to fetch results every time a new listener is added.
@@ -237,6 +249,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
     bool? eagerlyFetchResults,
     Context? context,
     ResultParserFn<TParsed>? parserFn,
+    Duration? queryRequestTimeout,
   }) =>
       WatchQueryOptions<TParsed>(
         document: document ?? this.document,
@@ -253,6 +266,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
             carryForwardDataOnException ?? this.carryForwardDataOnException,
         context: context ?? this.context,
         parserFn: parserFn ?? this.parserFn,
+        queryRequestTimeout: queryRequestTimeout ?? this.queryRequestTimeout,
       );
 
   WatchQueryOptions<TParsed> copyWithFetchPolicy(
@@ -272,6 +286,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         carryForwardDataOnException: carryForwardDataOnException,
         context: context,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
       );
   WatchQueryOptions<TParsed> copyWithPolicies(
     Policies policies,
@@ -290,6 +305,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         carryForwardDataOnException: carryForwardDataOnException,
         context: context,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
       );
 
   WatchQueryOptions<TParsed> copyWithPollInterval(Duration? pollInterval) =>
@@ -307,6 +323,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         carryForwardDataOnException: carryForwardDataOnException,
         context: context,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
       );
 
   WatchQueryOptions<TParsed> copyWithVariables(
@@ -325,6 +342,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         carryForwardDataOnException: carryForwardDataOnException,
         context: context,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
       );
 
   WatchQueryOptions<TParsed> copyWithOptimisticResult(
@@ -343,6 +361,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         carryForwardDataOnException: carryForwardDataOnException,
         context: context,
         parserFn: parserFn,
+        queryRequestTimeout: queryRequestTimeout,
       );
 }
 
@@ -358,6 +377,7 @@ class FetchMoreOptions {
     this.document,
     this.variables = const {},
     required this.updateQuery,
+    Duration? queryRequestTimeout,
   });
 
   /// Automatically merge the results of [updateQuery] into `previousResultData`.
@@ -369,11 +389,13 @@ class FetchMoreOptions {
     DocumentNode? document,
     Map<String, dynamic> variables = const {},
     required UpdateQuery updateQuery,
+    Duration? queryRequestTimeout,
   }) =>
       FetchMoreOptions(
         document: document,
         variables: variables,
         updateQuery: partialUpdater(updateQuery),
+        queryRequestTimeout: queryRequestTimeout,
       );
 
   final DocumentNode? document;

--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -28,7 +28,7 @@ class GraphQLClient implements GraphQLDataProxy {
     bool alwaysRebroadcast = false,
     DeepEqualsFn? deepEquals,
     bool deduplicatePollers = false,
-    Duration queryRequestTimeout = const Duration(seconds: 5),
+    Duration? queryRequestTimeout = const Duration(seconds: 5),
   })  : defaultPolicies = defaultPolicies ?? DefaultPolicies(),
         queryManager = QueryManager(
           link: link,


### PR DESCRIPTION
### Breaking changes
none

#### Fixes / Enhancements

- Allow to specify a `queryRequestTimeout` in every option classes that extends `BaseOptions`. This new parameter overrides the `queryRequestTimeout` set in the `GraphQLClient` constructor.
- The `queryRequestTimeout` parameter from `GraphQLClient` constructor is now nullable. This will allow having no timeout on queries (#1473)