### PR TITLE
fix: update connectivity_plus version and Java compatibility for new Android configuration

### DIFF
--- a/packages/graphql_flutter/README.md
+++ b/packages/graphql_flutter/README.md
@@ -78,6 +78,48 @@ And then import it inside your dart code:
 import 'package:graphql_flutter/graphql_flutter.dart';
 ```
 
+## Android Build Requirements
+
+To ensure compatibility with the latest Android configurations, this project now requires **Java 17**. Please verify your development environment is set up accordingly:
+
+### 1️⃣ Check Your Java Version
+
+Run the following command to check your Java version:
+
+```sh
+java -version
+```
+
+Ensure the output indicates **Java 17**. If not, update your Java Development Kit (JDK) to version **17**.
+
+### 2️⃣ Update Gradle Settings
+
+Modify your `android/gradle/wrapper/gradle-wrapper.properties` file to use **Gradle 8.4**:
+
+```properties
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+```
+
+### 3️⃣ Configure Build Settings
+
+In your `android/app/build.gradle` file, update the `compileOptions` and `kotlinOptions` to **target Java 17**:
+
+```gradle
+android {
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+
+    kotlinOptions {
+        jvmTarget = "17"
+    }
+}
+```
+
+By ensuring your environment matches these requirements, you can prevent potential build issues related to Java version incompatibilities.
+
+
 ## Migration Guide
 Find the migration from version 3 to version 4 [here](./../../changelog-v3-v4.md).
 

--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.15.0
   path_provider: ^2.0.1
   path: ^1.9.0
-  connectivity_plus: ^6.0.3
+  connectivity_plus: ^6.1.3
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
   flutter_hooks: '>=0.18.2 <0.21.0'


### PR DESCRIPTION
### Description
This PR updates the connectivity_plus dependency to resolve [Issue #1466](https://github.com/zino-hofmann/graphql-flutter/issues/1466). The issue occurs due to outdated configurations in Android Gradle Plugin (AGP), leading to build failures with the following error:
```
Execution failed for task ':connectivity_plus:compileDebugJavaWithJavac'.
Could not resolve all files for configuration ':connectivity_plus:androidJdkImage'.
```

The solution involves:
- Updating `connectivity_plus` to the latest compatible version.
- Modifying `android/app/build.gradle` to ensure compatibility by updating:
```gradle
android {
    compileOptions {
        sourceCompatibility JavaVersion.VERSION_17
        targetCompatibility JavaVersion.VERSION_17
    }

    kotlinOptions {
        jvmTarget = "17"
    }
}
```
- Updating `gradle-wrapper.properties `in `android/gradle/wrapper`:

```properties
distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
```

These changes ensure the package builds successfully on newer Android configurations.

#### Fixes / Enhancements
Fixed: Android build failure due to outdated `connectivity_plus` and AGP incompatibility.
Added: Java 17 compatibility for both Java and Kotlin.
Updated: `distributionUrl` in `gradle-wrapper.properties`.

### Breaking changes
No breaking changes expected.

#### Docs

Updated README.md 

