### PR TITLE
fix(graphql_flutter): fix the graphql flutter

### DIFF
--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -8,7 +8,7 @@ issue_tracker: https://github.com/zino-hofmann/graphql-flutter/issues
 # publish_to: 'none'
 
 dependencies:
-  graphql: ^5.2.0-beta.8
+  graphql: ^5.2.0
   gql_exec: ^1.0.0
   flutter:
     sdk: flutter


### PR DESCRIPTION
Total compressed archive size: 123 KB.
Validating package...
Package validation found the following potential issue:
* Packages dependent on a pre-release of another package should themselves be published as a pre-release version. If this package needs graphql version 5.2.0-beta.8, consider publishing the package as a pre-release instead. See https://dart.dev/tools/pub/publishing#publishing-prereleases For more information on pre-releases. The server may enforce additional checks.

Package has 1 warning.
Failed to update packages.

Fixes https://github.com/zino-hofmann/graphql-flutter/issues/1489

