### PR TITLE
chore(graphql): upgrade flutter_hooks 0.21.2

### DIFF
--- a/packages/graphql_flutter/pubspec.yaml
+++ b/packages/graphql_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   connectivity_plus: ^6.1.3
   hive: ^2.0.0
   plugin_platform_interface: ^2.0.0
-  flutter_hooks: '>=0.18.2 <0.21.0'
+  flutter_hooks: '>=0.18.2 <0.22.0'
 
 dev_dependencies:
   pedantic: ^1.11.0


### PR DESCRIPTION
This pull request updates the version constraint for the `flutter_hooks` dependency in the `packages/graphql_flutter/pubspec.yaml` file to allow compatibility with newer versions.

Dependency update:

* [`packages/graphql_flutter/pubspec.yaml`](diffhunk://#diff-8f6293e6338d3f5bd980e18143fe2569fbf49d654b49dc5b2c8b7e1e592b9d1aL21-R21): Updated the `flutter_hooks` dependency version constraint from `>=0.18.2 <0.21.0` to `>=0.18.2 <0.22.0` to support newer versions of the library.