### PR TITLE
feat(graphql): add asyncDeepEquals to the graphqlClient

### DIFF
--- a/packages/graphql/lib/src/core/observable_query.dart
+++ b/packages/graphql/lib/src/core/observable_query.dart
@@ -90,7 +90,7 @@ class ObservableQuery<TParsed> {
   /// same as [_onDataCallbacks], but not removed after invocation
   Set<OnData<TParsed>> _notRemovableOnDataCallbacks = Set();
 
-  /// call [queryManager.maybeRebroadcastQueries] after all other [_onDataCallbacks]
+  /// call [queryManager.maybeRebroadcastQueriesAsync] after all other [_onDataCallbacks]
   ///
   /// Automatically appended as an [OnData]
   FutureOr<void> _maybeRebroadcast(QueryResult? result) {
@@ -101,10 +101,10 @@ class ObservableQuery<TParsed> {
       // data. It's valid GQL to have data _and_ exception. If options.carryForwardDataOnException
       // are true, this condition may never get hit.
       // If there are onDataCallbacks, it's possible they modify cache and are
-      // depending on maybeRebroadcastQueries being called.
+      // depending on maybeRebroadcastQueriesAsync being called.
       return false;
     }
-    return queryManager.maybeRebroadcastQueries(exclude: this);
+    return queryManager.maybeRebroadcastQueriesAsync(exclude: this);
   }
 
   /// The most recently seen result from this operation's stream

--- a/packages/graphql/lib/src/graphql_client.dart
+++ b/packages/graphql/lib/src/graphql_client.dart
@@ -27,6 +27,7 @@ class GraphQLClient implements GraphQLDataProxy {
     DefaultPolicies? defaultPolicies,
     bool alwaysRebroadcast = false,
     DeepEqualsFn? deepEquals,
+    AsyncDeepEqualsFn? asyncDeepEquals,
     bool deduplicatePollers = false,
     Duration? queryRequestTimeout = const Duration(seconds: 5),
   })  : defaultPolicies = defaultPolicies ?? DefaultPolicies(),
@@ -35,6 +36,7 @@ class GraphQLClient implements GraphQLDataProxy {
           cache: cache,
           alwaysRebroadcast: alwaysRebroadcast,
           deepEquals: deepEquals,
+          asyncDeepEquals: asyncDeepEquals,
           deduplicatePollers: deduplicatePollers,
           requestTimeout: queryRequestTimeout,
         );
@@ -57,6 +59,7 @@ class GraphQLClient implements GraphQLDataProxy {
     DefaultPolicies? defaultPolicies,
     bool? alwaysRebroadcast,
     DeepEqualsFn? deepEquals,
+    AsyncDeepEqualsFn? asyncDeepEquals,
     bool deduplicatePollers = false,
     Duration? queryRequestTimeout,
   }) {
@@ -66,6 +69,7 @@ class GraphQLClient implements GraphQLDataProxy {
       defaultPolicies: defaultPolicies ?? this.defaultPolicies,
       alwaysRebroadcast: alwaysRebroadcast ?? queryManager.alwaysRebroadcast,
       deepEquals: deepEquals,
+      asyncDeepEquals: asyncDeepEquals,
       deduplicatePollers: deduplicatePollers,
       queryRequestTimeout: queryRequestTimeout ?? queryManager.requestTimeout,
     );
@@ -269,7 +273,7 @@ class GraphQLClient implements GraphQLDataProxy {
   /// pass through to [cache.writeQuery] and then rebroadcast any changes.
   void writeQuery(request, {required data, broadcast = true}) {
     cache.writeQuery(request, data: data, broadcast: broadcast);
-    queryManager.maybeRebroadcastQueries();
+    queryManager.maybeRebroadcastQueriesAsync().ignore();
   }
 
   /// pass through to [cache.writeFragment] and then rebroadcast any changes.
@@ -283,7 +287,7 @@ class GraphQLClient implements GraphQLDataProxy {
       broadcast: broadcast,
       data: data,
     );
-    queryManager.maybeRebroadcastQueries();
+    queryManager.maybeRebroadcastQueriesAsync();
   }
 
   /// Resets the contents of the store with [cache.store.reset()]


### PR DESCRIPTION
#### Fixes / Enhancements

- Added `asyncDeepEquals` param to the `GraphqlClient` as the DeepCollectionEquality is an expensive operation and was running synchronously. This in turn would result in a jank whenever there is a response received and the equality check happens in the `_cachedDataHasChangedFor` function.
- To avoid the jank the developer can pass the async function for equality check, like `compute()` to move the operation to a different isolate.
- This also partially fixes https://github.com/zino-hofmann/graphql-flutter/issues/1196

<table>
  <tr>
    <td width="50%">
Before
      <img src="https://github.com/user-attachments/assets/58db2123-fd20-4880-b706-a87f76498fee" width="100%">
    </td>
    <td width="50%">
After
      <img src="https://github.com/user-attachments/assets/fa126467-7fb8-4edd-be5d-51406633a106" width="100%">
    </td>
  </tr>
</table>