### PR TITLE
fix(graphql): guard query completer when stream emits multiple responses

### DIFF
--- a/packages/graphql/lib/src/core/query_manager.dart
+++ b/packages/graphql/lib/src/core/query_manager.dart
@@ -282,13 +282,19 @@ class QueryManager {
       }
 
       // Listen for the first response or error
-      responseStream.listen(completer.complete,
-          onError: (Object error, StackTrace stackTrace) {
-        if (!completer.isCompleted) {
-          // We return the first error encountered
-          completer.completeError(error, stackTrace);
-        }
-      });
+      responseStream.listen(
+        (Response value) {
+          if (!completer.isCompleted) {
+            completer.complete(value);
+          }
+        },
+        onError: (Object error, StackTrace stackTrace) {
+          if (!completer.isCompleted) {
+            // We return the first error encountered
+            completer.completeError(error, stackTrace);
+          }
+        },
+      );
 
       // Await the response or error
       response = await completer.future;

--- a/packages/graphql/test/query_manager_test.dart
+++ b/packages/graphql/test/query_manager_test.dart
@@ -42,5 +42,31 @@ void main() {
       );
       client.queryManager.refetchQuery<dynamic>(observable.queryId);
     });
+
+    test('uses first response when link emits multiple events', () async {
+      const ping = 'ping';
+
+      when(link.request(any)).thenAnswer(
+        (_) => Stream.fromIterable(<Response>[
+          Response(
+            data: <String, dynamic>{ping: 1},
+            response: <String, dynamic>{},
+          ),
+          Response(
+            data: <String, dynamic>{ping: 2},
+            response: <String, dynamic>{},
+          ),
+        ]),
+      );
+
+      final result = await client.query(
+        QueryOptions(
+          document: parseString('{$ping}'),
+          fetchPolicy: FetchPolicy.networkOnly,
+        ),
+      );
+
+      expect(result.data![ping], 1);
+    });
   });
 }


### PR DESCRIPTION
## Summary

`QueryManager` completed the same `Completer` on every `Response` from the link stream. If the link emitted more than one event (e.g. multiple `Response`s), the second completion threw **Bad state: Future already completed**. This change only completes when the completer is still pending, consistent with the existing `onError` path.

**Why merge:** Fixes a runtime crash for any setup where the link stream can emit multiple values for a single query, and adds a regression test so the first emitted response is used when multiple emissions occur.

#### Reproduction
Observed in the app with a very short `queryRequestTimeout` and `TimedInMemoryStore`, which can surface multiple stream events and trigger **Bad state: Future already completed**:
```dart
return GraphQLClient(
  link: links,
  cache: GraphQLCache(
    store: TimedInMemoryStore(),
  ),
  queryRequestTimeout: const Duration(milliseconds: 1),
);
```

### Breaking changes

None.

#### Fixes / Enhancements

- Fixed `QueryManager` calling `completer.complete` for every stream event; the first response is used when multiple events are emitted.
- Added a unit test that asserts the first emitted `Response` is used when the link stream yields multiple responses.

#### Docs

- N/A.