### PR TITLE
fix(graphql): let a query opt out of DedupeLink deduplication

### DIFF
--- a/packages/graphql/CHANGELOG.md
+++ b/packages/graphql/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Added
+- add `queryDeduplication` to `QueryOptions`/`MutationOptions`, `QueryDeduplicationContextEntry`, and its `QueryDeduplicationContextEntry.shouldDedupe` predicate, so a `DedupeLink` can be configured (`DedupeLink(shouldDedupe: QueryDeduplicationContextEntry.shouldDedupe)`) to let an individual operation opt out of deduplication, fixing [#1384](https://github.com/zino-hofmann/graphql-flutter/issues/1384). @Yasser-Ameur
+
+
 # v5.2.3
 
 ## Fixed

--- a/packages/graphql/README.md
+++ b/packages/graphql/README.md
@@ -1051,6 +1051,23 @@ When combining links, **it is important to note that**:
 - Terminating links like `HttpLink` and `WebsocketLink` must come at the end of a route, and will not call links following them.
 - Link order is very important. In `HttpLink(myEndpoint).concat(AuthLink(getToken: authenticate))`, the `AuthLink` will never be called.
 
+#### Opting a query out of `DedupeLink`
+
+`DedupeLink()` (as wired up above) deduplicates **every** request by default: identical, concurrent operations collapse into a single network call, with no way to opt out per-call ([see #1384](https://github.com/zino-hofmann/graphql-flutter/issues/1384)). Since that default cannot be changed from this package, the flag needs one line of wiring: pass `QueryDeduplicationContextEntry.shouldDedupe` as `DedupeLink`'s `shouldDedupe` predicate, then set the entry per-call via `QueryOptions`/`MutationOptions`' `queryDeduplication`:
+
+```dart
+final link = DedupeLink(
+  shouldDedupe: QueryDeduplicationContextEntry.shouldDedupe,
+).concat(httpLink);
+
+// deduplicated by default, same as before:
+client.query(QueryOptions(document: myQuery));
+
+// opts this call out of deduplication, so concurrent, identical calls each
+// hit the network:
+client.query(QueryOptions(document: myQuery, queryDeduplication: false));
+```
+
 ### AWS AppSync Support
 
 **Cognito Pools**

--- a/packages/graphql/lib/src/core/_base_options.dart
+++ b/packages/graphql/lib/src/core/_base_options.dart
@@ -25,6 +25,7 @@ abstract class BaseOptions<TParsed extends Object?> {
     this.optimisticResult,
     this.queryRequestTimeout,
     this.cancellationToken,
+    this.queryDeduplication,
   })  : policies = Policies(
           fetch: fetchPolicy,
           error: errorPolicy,
@@ -71,6 +72,18 @@ abstract class BaseOptions<TParsed extends Object?> {
   /// with a [CancelledException].
   final CancellationToken? cancellationToken;
 
+  /// Whether this operation should be deduplicated with other in-flight,
+  /// identical operations by a [DedupeLink] in the link chain.
+  ///
+  /// `null` (the default) leaves the [Context] untouched, so a [DedupeLink]
+  /// deduplicates as it always has (every request, unless it was built with
+  /// a custom `shouldDedupe`). Passing `false` attaches a
+  /// [QueryDeduplicationContextEntry] that a [DedupeLink] can read via its
+  /// `shouldDedupe` predicate to skip deduplication for this operation only,
+  /// mirroring Apollo Client's per-query `queryDeduplication` option. See
+  /// [QueryDeduplicationContextEntry] for the predicate to wire up.
+  final bool? queryDeduplication;
+
   // TODO consider inverting this relationship
   /// Resolve these options into a request
   Request get asRequest => Request(
@@ -79,7 +92,11 @@ abstract class BaseOptions<TParsed extends Object?> {
           operationName: operationName,
         ),
         variables: variables,
-        context: context,
+        context: queryDeduplication == null
+            ? context
+            : context.withEntry(
+                QueryDeduplicationContextEntry(dedupe: queryDeduplication!),
+              ),
       );
 
   @protected
@@ -93,6 +110,7 @@ abstract class BaseOptions<TParsed extends Object?> {
         parserFn,
         queryRequestTimeout,
         cancellationToken,
+        queryDeduplication,
       ];
 
   OperationType get type {

--- a/packages/graphql/lib/src/core/mutation_options.dart
+++ b/packages/graphql/lib/src/core/mutation_options.dart
@@ -32,6 +32,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
     ResultParserFn<TParsed>? parserFn,
     Duration? queryRequestTimeout,
     CancellationToken? cancellationToken,
+    bool? queryDeduplication,
   }) : super(
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -44,6 +45,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
           parserFn: parserFn,
           queryRequestTimeout: queryRequestTimeout,
           cancellationToken: cancellationToken,
+          queryDeduplication: queryDeduplication,
         );
 
   final OnMutationCompleted? onCompleted;
@@ -75,6 +77,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
     ResultParserFn<TParsed>? parserFn,
     Duration? queryRequestTimeout,
     CancellationToken? cancellationToken,
+    bool? queryDeduplication,
   }) =>
       MutationOptions<TParsed>(
         document: document ?? this.document,
@@ -91,6 +94,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         parserFn: parserFn ?? this.parserFn,
         queryRequestTimeout: queryRequestTimeout ?? this.queryRequestTimeout,
         cancellationToken: cancellationToken ?? this.cancellationToken,
+        queryDeduplication: queryDeduplication ?? this.queryDeduplication,
       );
 
   MutationOptions<TParsed> copyWithPolicies(Policies policies) =>
@@ -109,6 +113,7 @@ class MutationOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
         cancellationToken: cancellationToken,
+        queryDeduplication: queryDeduplication,
       );
 
   WatchQueryOptions<TParsed> asWatchQueryOptions() =>

--- a/packages/graphql/lib/src/core/query_options.dart
+++ b/packages/graphql/lib/src/core/query_options.dart
@@ -31,6 +31,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
     this.onComplete,
     this.onError,
     CancellationToken? cancellationToken,
+    bool? queryDeduplication,
   }) : super(
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -43,6 +44,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
           parserFn: parserFn,
           queryRequestTimeout: queryRequestTimeout,
           cancellationToken: cancellationToken,
+          queryDeduplication: queryDeduplication,
         );
 
   final OnQueryComplete? onComplete;
@@ -76,6 +78,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
     OnQueryComplete? onComplete,
     OnQueryError? onError,
     CancellationToken? cancellationToken,
+    bool? queryDeduplication,
   }) =>
       QueryOptions<TParsed>(
         document: document ?? this.document,
@@ -92,6 +95,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         onComplete: onComplete ?? this.onComplete,
         onError: onError ?? this.onError,
         cancellationToken: cancellationToken ?? this.cancellationToken,
+        queryDeduplication: queryDeduplication ?? this.queryDeduplication,
       );
 
   QueryOptions<TParsed> withFetchMoreOptions(
@@ -106,6 +110,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         queryRequestTimeout: queryRequestTimeout,
         context: context,
         cancellationToken: cancellationToken,
+        queryDeduplication: queryDeduplication,
         variables: {
           ...variables,
           ...fetchMoreOptions.variables,
@@ -127,6 +132,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
         cancellationToken: cancellationToken,
+        queryDeduplication: queryDeduplication,
       );
 
   QueryOptions<TParsed> copyWithPolicies(Policies policies) => QueryOptions(
@@ -142,6 +148,7 @@ class QueryOptions<TParsed extends Object?> extends BaseOptions<TParsed> {
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
         cancellationToken: cancellationToken,
+        queryDeduplication: queryDeduplication,
       );
 }
 
@@ -160,6 +167,7 @@ class SubscriptionOptions<TParsed extends Object?>
     ResultParserFn<TParsed>? parserFn,
     Duration? queryRequestTimeout,
     CancellationToken? cancellationToken,
+    bool? queryDeduplication,
   }) : super(
           fetchPolicy: fetchPolicy,
           errorPolicy: errorPolicy,
@@ -172,6 +180,7 @@ class SubscriptionOptions<TParsed extends Object?>
           parserFn: parserFn,
           queryRequestTimeout: queryRequestTimeout,
           cancellationToken: cancellationToken,
+          queryDeduplication: queryDeduplication,
         );
   SubscriptionOptions<TParsed> copyWithPolicies(Policies policies) =>
       SubscriptionOptions(
@@ -186,6 +195,7 @@ class SubscriptionOptions<TParsed extends Object?>
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
         cancellationToken: cancellationToken,
+        queryDeduplication: queryDeduplication,
       );
 }
 
@@ -207,6 +217,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
     ResultParserFn<TParsed>? parserFn,
     Duration? queryRequestTimeout,
     CancellationToken? cancellationToken,
+    bool? queryDeduplication,
   })  : eagerlyFetchResults = eagerlyFetchResults ?? fetchResults,
         super(
           document: document,
@@ -221,6 +232,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
           parserFn: parserFn,
           queryRequestTimeout: queryRequestTimeout,
           cancellationToken: cancellationToken,
+          queryDeduplication: queryDeduplication,
         );
 
   /// Whether or not to fetch results every time a new listener is added.
@@ -263,6 +275,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
     ResultParserFn<TParsed>? parserFn,
     Duration? queryRequestTimeout,
     CancellationToken? cancellationToken,
+    bool? queryDeduplication,
   }) =>
       WatchQueryOptions<TParsed>(
         document: document ?? this.document,
@@ -281,6 +294,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         parserFn: parserFn ?? this.parserFn,
         queryRequestTimeout: queryRequestTimeout ?? this.queryRequestTimeout,
         cancellationToken: cancellationToken ?? this.cancellationToken,
+        queryDeduplication: queryDeduplication ?? this.queryDeduplication,
       );
 
   WatchQueryOptions<TParsed> copyWithFetchPolicy(
@@ -302,6 +316,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
         cancellationToken: cancellationToken,
+        queryDeduplication: queryDeduplication,
       );
   WatchQueryOptions<TParsed> copyWithPolicies(
     Policies policies,
@@ -322,6 +337,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
         cancellationToken: cancellationToken,
+        queryDeduplication: queryDeduplication,
       );
 
   WatchQueryOptions<TParsed> copyWithPollInterval(Duration? pollInterval) =>
@@ -341,6 +357,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
         cancellationToken: cancellationToken,
+        queryDeduplication: queryDeduplication,
       );
 
   WatchQueryOptions<TParsed> copyWithVariables(
@@ -361,6 +378,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
         cancellationToken: cancellationToken,
+        queryDeduplication: queryDeduplication,
       );
 
   WatchQueryOptions<TParsed> copyWithOptimisticResult(
@@ -381,6 +399,7 @@ class WatchQueryOptions<TParsed extends Object?> extends QueryOptions<TParsed> {
         parserFn: parserFn,
         queryRequestTimeout: queryRequestTimeout,
         cancellationToken: cancellationToken,
+        queryDeduplication: queryDeduplication,
       );
 }
 

--- a/packages/graphql/lib/src/links/links.dart
+++ b/packages/graphql/lib/src/links/links.dart
@@ -2,3 +2,4 @@
 export 'package:graphql/src/links/gql_links.dart';
 export 'package:graphql/src/links/auth_link.dart';
 export 'package:graphql/src/links/websocket_link/websocket_link.dart';
+export 'package:graphql/src/links/query_deduplication_context.dart';

--- a/packages/graphql/lib/src/links/query_deduplication_context.dart
+++ b/packages/graphql/lib/src/links/query_deduplication_context.dart
@@ -1,0 +1,40 @@
+import 'package:gql_exec/gql_exec.dart';
+
+/// A [ContextEntry] flagging whether a [Request] should be deduplicated by a
+/// [DedupeLink] in the link chain.
+///
+/// [DedupeLink] (from `gql_dedupe_link`, re-exported by this package)
+/// deduplicates every request by default: identical, concurrent operations
+/// collapse into a single network call. That default has no way to be
+/// bypassed per-operation, so an entry of this type gives call sites a way
+/// to opt individual queries or mutations out of deduplication, mirroring
+/// Apollo Client's per-query `queryDeduplication` option.
+///
+/// Set it via [BaseOptions.queryDeduplication] (e.g.
+/// `QueryOptions(..., queryDeduplication: false)`) and read it from a
+/// [DedupeLink]'s `shouldDedupe` predicate. [shouldDedupe] is that
+/// predicate, ready to wire in directly:
+///
+/// ```dart
+/// DedupeLink(shouldDedupe: QueryDeduplicationContextEntry.shouldDedupe),
+/// ```
+///
+/// Absent from the [Context] (the default), it should be treated as `true`
+/// so existing [DedupeLink] configurations keep deduplicating everything.
+class QueryDeduplicationContextEntry extends ContextEntry {
+  const QueryDeduplicationContextEntry({this.dedupe = true});
+
+  /// Whether this request should be deduplicated with other in-flight,
+  /// identical requests. Defaults to `true`.
+  final bool dedupe;
+
+  /// A [DedupeLink] `shouldDedupe` predicate that reads a request's
+  /// [QueryDeduplicationContextEntry]: `false` when the entry is present
+  /// with `dedupe: false`, `true` otherwise (matching [DedupeLink]'s own
+  /// default of deduplicating every request).
+  static bool shouldDedupe(Request request) =>
+      request.context.entry<QueryDeduplicationContextEntry>()?.dedupe ?? true;
+
+  @override
+  List<Object?> get fieldsForEquality => [dedupe];
+}

--- a/packages/graphql/test/graphql_client_test.dart
+++ b/packages/graphql/test/graphql_client_test.dart
@@ -154,6 +154,107 @@ void main() {
           equals('bar'),
         );
       });
+      test(
+          'issue 1384, DedupeLink collapses concurrent identical queries '
+          'unless queryDeduplication opts a query out', () async {
+        final _options = QueryOptions(
+          document: parseString(readRepositories),
+          variables: <String, dynamic>{
+            'nRepositories': 42,
+          },
+          fetchPolicy: FetchPolicy.networkOnly,
+        );
+        final repoData = readRepositoryData(withTypenames: true);
+
+        final dedupingLink = MockLink();
+        when(
+          dedupingLink.request(any),
+        ).thenAnswer(
+          (_) => Stream.fromIterable([
+            Response(
+              data: repoData,
+              response: {},
+            ),
+          ]),
+        );
+        final dedupedClient = GraphQLClient(
+          cache: getTestCache(),
+          link: DedupeLink(
+                  shouldDedupe: QueryDeduplicationContextEntry.shouldDedupe)
+              .concat(dedupingLink),
+        );
+
+        // Reproduces https://github.com/zino-hofmann/graphql-flutter/issues/1384:
+        // with a DedupeLink in the chain, firing the same `networkOnly`
+        // query 5 times concurrently collapses into a single network call.
+        final dedupedResults = await Future.wait(
+          List.generate(5, (_) => dedupedClient.query(_options)),
+        );
+        for (final r in dedupedResults) {
+          expect(r.exception, isNull);
+          expect(r.data, equals(repoData));
+        }
+        verify(dedupingLink.request(any)).called(1);
+
+        // Opting an individual query out of deduplication (mirroring Apollo
+        // Client's per-query `queryDeduplication` option) makes every
+        // concurrent call reach the network.
+        final passThroughLink = MockLink();
+        when(
+          passThroughLink.request(any),
+        ).thenAnswer(
+          (_) => Stream.fromIterable([
+            Response(
+              data: repoData,
+              response: {},
+            ),
+          ]),
+        );
+        final optedOutClient = GraphQLClient(
+          cache: getTestCache(),
+          link: DedupeLink(
+                  shouldDedupe: QueryDeduplicationContextEntry.shouldDedupe)
+              .concat(passThroughLink),
+        );
+        final optedOutOptions =
+            _options.copyWithOptions(queryDeduplication: false);
+
+        final optedOutResults = await Future.wait(
+          List.generate(5, (_) => optedOutClient.query(optedOutOptions)),
+        );
+        for (final r in optedOutResults) {
+          expect(r.exception, isNull);
+          expect(r.data, equals(repoData));
+        }
+        verify(passThroughLink.request(any)).called(5);
+      });
+      test(
+          'QueryDeduplicationContextEntry.shouldDedupe defaults to true, '
+          'false only when the entry says queryDeduplication: false', () async {
+        final noEntry = Request(
+          operation: Operation(document: parseString(readRepositories)),
+        );
+        final dedupeTrue = Request(
+          operation: Operation(document: parseString(readRepositories)),
+          context: Context()
+              .withEntry(const QueryDeduplicationContextEntry(dedupe: true)),
+        );
+        final dedupeFalse = Request(
+          operation: Operation(document: parseString(readRepositories)),
+          context: Context()
+              .withEntry(const QueryDeduplicationContextEntry(dedupe: false)),
+        );
+
+        expect(QueryDeduplicationContextEntry.shouldDedupe(noEntry), isTrue);
+        expect(
+          QueryDeduplicationContextEntry.shouldDedupe(dedupeTrue),
+          isTrue,
+        );
+        expect(
+          QueryDeduplicationContextEntry.shouldDedupe(dedupeFalse),
+          isFalse,
+        );
+      });
       test('issue 1208', () async {
         final client = GraphQLClient(
           cache: GraphQLCache(


### PR DESCRIPTION
## Description

Firing the same query several times in parallel produces one network request (#1384). That is `DedupeLink` doing its job: `gql_dedupe_link` deduplicates every request by default, and the README's own link chain wires `DedupeLink()` in front of everything. What is missing is a way for one call to opt out, the way Apollo Client's per-query `queryDeduplication` does. `QueryManager` itself does not collapse requests; a chain without `DedupeLink` already issues five calls for five concurrent `networkOnly` queries.

This adds:

- `queryDeduplication` on `QueryOptions`, `MutationOptions`, `SubscriptionOptions` and `WatchQueryOptions` (and every `copyWith*` variant). Unset by default, so no existing caller changes behaviour. When set, `asRequest` attaches a `QueryDeduplicationContextEntry` to the request context through the existing `withEntry` helper, leaving other context entries intact.
- `QueryDeduplicationContextEntry.shouldDedupe`, a ready-made predicate so the wiring is one line: `DedupeLink(shouldDedupe: QueryDeduplicationContextEntry.shouldDedupe)`. It returns `false` only for a request carrying `queryDeduplication: false`, and `true` otherwise, matching `DedupeLink`'s current default.
- README subsection "Opting a query out of `DedupeLink`" and a CHANGELOG entry under Unreleased.

Why the flag needs one line of wiring: `DedupeLink` lives in `gql_dedupe_link`, so its default cannot be changed from this package. Shipping the predicate keeps the opt-out from being a closure every consumer copies.

#### Fixes / Enhancements

- Added `queryDeduplication` to the options classes and `QueryDeduplicationContextEntry` with its `shouldDedupe` predicate, so an individual operation can opt out of `DedupeLink` deduplication (#1384). Default unchanged.

#### Docs

- Added the README subsection on opting a query out of `DedupeLink`, and the CHANGELOG entry.

**Tests.** `test/graphql_client_test.dart`: five concurrent identical `networkOnly` queries through `DedupeLink(shouldDedupe: QueryDeduplicationContextEntry.shouldDedupe)` make one underlying call; the same five with `queryDeduplication: false` make five; plus unit assertions on the predicate for no entry, `true` and `false`. The test does not compile against `main`. `dart analyze`: no issues. `dart test test/graphql_client_test.dart`: 29 passed. `dart format --set-exit-if-changed`: unchanged.

Fixes #1384
